### PR TITLE
test: execute the instruction-counting path and assert its determinism

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - uses: Swatinem/rust-cache@v2
+
+      # The whole premise of this project is that instruction counts are stable
+      # enough to gate on. That path is a subprocess call, so it can only be
+      # exercised where valgrind exists — and it once shipped having never run.
+      # Installing it here is what keeps tests/counters.rs meaningful.
+      - name: Install valgrind
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends valgrind
+
+      - run: valgrind --version
+
+      - run: cargo fmt --check
+      - run: cargo clippy --all-targets -- -D warnings
+      - run: cargo test --all-targets
+
+  # macOS has no usable cachegrind, so counters are expected to be absent here.
+  # This job asserts the degradation path rather than the measurement path.
+  test-macos:
+    runs-on: macos-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --all-targets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,25 @@ jobs:
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo test --all-targets
+
+  # Single fan-in gate, so branch protection requires one check instead of an
+  # enumerated list that goes stale every time a job is added or renamed. It
+  # also catches *skipped* jobs, which a required check would otherwise treat
+  # as passing.
+  final:
+    permissions: {}
+    needs:
+      - test
+      - test-macos
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    # Run on success or upstream failure but skip when the workflow is cancelled
+    # — `always()` would override `cancel-in-progress` and waste a runner.
+    if: ${{ !cancelled() }}
+    steps:
+      - name: Check job results
+        if: |
+          needs.test.result != 'success' ||
+          needs.test-macos.result != 'success'
+        run: exit 1
+      - run: echo "All CI jobs completed successfully"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,20 +15,23 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
 
+# Actions are pinned to full commit SHAs. A mutable tag like @v2 or @stable can
+# be retargeted at any time, which would swap out executable CI code without
+# review.
 jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
           components: clippy, rustfmt
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       # The whole premise of this project is that instruction counts are stable
       # enough to gate on. That path is a subprocess call, so it can only be
@@ -49,9 +52,9 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo test --all-targets

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,10 @@ license = "MIT"
 repository = "https://github.com/jdx/tak"
 publish = false
 
+[lib]
+name = "tak_cli"
+path = "src/lib.rs"
+
 [[bin]]
 name = "tak"
 path = "src/main.rs"

--- a/README.md
+++ b/README.md
@@ -108,9 +108,15 @@ there records timing only and says so. Run it in a container to get the
 deterministic metric on any host:
 
 ```sh
-docker build -t tak docker/
-docker run --rm -v "$PWD:/w" -w /w tak run --bench startup -- ./mycli --help
+docker build -f docker/Dockerfile -t tak .
+docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/w" -w /w \
+  tak run --bench startup -- ./mycli --help
 ```
+
+The build context is the repository root, not `docker/`, because the build stage copies
+`Cargo.toml` and `src/`. And `--user` is not decoration: `tak` spawns the thing you are
+measuring, so the benchmark subject inherits the container's privileges over the mounted
+working tree.
 
 The CI gate lives on the Linux job regardless, so this only matters locally.
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ variation across metrics:
 Under 3.2× CPU oversubscription, wall-clock medians moved about 150%. Instruction counts moved
 0.035%. So: **gate CI on instruction counts, report wall clock without gating.**
 
+Re-measured through `tak` itself, benchmarking `/bin/ls /usr` in a container, quiet versus
+32 spinning cores:
+
+| metric | quiet | 32-way contention |
+|---|---|---|
+| `instructions` | 536124 | **536124** — byte-identical, 8/8 runs |
+| `wall_min_ms` | 0.66 | 0.66 – 1.17 (**77% swing**) |
+
+`tests/counters.rs` asserts that determinism on every CI run, and skips cleanly where valgrind
+is unavailable.
+
 Corollary that cost me an afternoon to learn: syscall count and max RSS are *not* deterministic
 — they move with thread scheduling. Only instruction counts support a tight gate.
 
@@ -78,16 +89,30 @@ on-disk size:                            124K
 
 ## Status
 
-Nothing works yet. This is a skeleton.
+Measuring and storing work. Nothing reads the data back yet.
 
-- [ ] `tak run` — measure a command
-- [ ] wall clock, interleaved A/B
-- [ ] instruction counts via cachegrind
-- [ ] `refs/notes/tak` storage
+- [x] `tak run` — wall clock (min / p50 / mean / max), no shell
+- [x] instruction counts via cachegrind, degrading to timing-only where absent
+- [x] `refs/notes/tak` storage — `run --record`, `push`, `history`, `init`
+- [x] concurrent CI writers merge via `cat_sort_uniq`
 - [ ] `tak backfill --releases` — benchmark published release binaries to bootstrap history
-- [ ] `tak compare <ref>`
+- [ ] `tak compare <ref>` — interleaved A/B against another revision
+- [ ] `bench.toml`
 - [ ] PR reporting
 - [ ] change-point detection instead of thresholds
+
+## Counters on macOS and Windows
+
+There is no usable cachegrind on Apple Silicon and none on Windows, so `tak run`
+there records timing only and says so. Run it in a container to get the
+deterministic metric on any host:
+
+```sh
+docker build -t tak docker/
+docker run --rm -v "$PWD:/w" -w /w tak run --bench startup -- ./mycli --help
+```
+
+The CI gate lives on the Linux job regardless, so this only matters locally.
 
 ## Prior art this steals from
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,23 +1,38 @@
 # Instruction counting needs cachegrind, and there is no usable valgrind on
 # Apple Silicon or Windows. Running tak in here gets you the deterministic
-# metric on any host — the binary is measured inside the container, so the
-# numbers are comparable to what Linux CI produces.
+# metric on any host.
 #
-#   docker build -t tak docker/
-#   docker run --rm -v "$PWD:/w" -w /w tak run --bench startup -- ./mycli --help
+# The build context is the repository root, not this directory, because the
+# build stage copies Cargo.toml and src/:
 #
-# Note that measuring a *host-built* binary works too, as long as the container's
-# glibc is at least as new as the one it was linked against.
+#   docker build -f docker/Dockerfile -t tak .
+#   docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/w" -w /w \
+#     tak run --bench startup -- ./mycli --help
+#
+# `--user` matters: tak spawns the benchmark subject, so whatever you are
+# measuring inherits the container's privileges over the mounted working tree.
+# Mapping to your own uid keeps a faulty subject from writing root-owned files
+# into your checkout.
+#
+# Measuring a *host-built* binary works too, as long as the container's glibc is
+# at least as new as the one it was linked against.
 
 FROM rust:1-slim-trixie AS build
 WORKDIR /src
 COPY Cargo.toml Cargo.lock ./
 COPY src ./src
-RUN cargo build --release
+RUN cargo build --release --bin tak
 
 FROM debian:trixie-slim
 RUN apt-get update \
- && apt-get install -y --no-install-recommends valgrind git ca-certificates \
+ && apt-get install -y --no-install-recommends \
+      valgrind curl tar gzip xz-utils unzip git ca-certificates \
  && rm -rf /var/lib/apt/lists/*
 COPY --from=build /src/target/release/tak /usr/local/bin/tak
+
+# Default to an unprivileged user so the benchmark subject is not root out of
+# the box. Override with `--user` to match your own uid when writing to a mount.
+RUN useradd --create-home --uid 1000 tak
+USER tak
+
 ENTRYPOINT ["tak"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,23 @@
+# Instruction counting needs cachegrind, and there is no usable valgrind on
+# Apple Silicon or Windows. Running tak in here gets you the deterministic
+# metric on any host — the binary is measured inside the container, so the
+# numbers are comparable to what Linux CI produces.
+#
+#   docker build -t tak docker/
+#   docker run --rm -v "$PWD:/w" -w /w tak run --bench startup -- ./mycli --help
+#
+# Note that measuring a *host-built* binary works too, as long as the container's
+# glibc is at least as new as the one it was linked against.
+
+FROM rust:1-slim-trixie AS build
+WORKDIR /src
+COPY Cargo.toml Cargo.lock ./
+COPY src ./src
+RUN cargo build --release
+
+FROM debian:trixie-slim
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends valgrind git ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+COPY --from=build /src/target/release/tak /usr/local/bin/tak
+ENTRYPOINT ["tak"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,11 @@
+//! tak — benchmark command-line programs and track their performance over time.
+//!
+//! Experimental. See README.md, which asks you to use hyperfine instead.
+//!
+//! Exposed as a library so the measurement and storage layers can be exercised
+//! by integration tests. `measure::instructions` in particular went a long time
+//! written-but-never-executed, which is exactly the failure this guards against.
+
+pub mod measure;
+pub mod notes;
+pub mod record;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,16 +2,13 @@
 //!
 //! Experimental. See README.md, which asks you to use hyperfine instead.
 
-mod measure;
-mod notes;
-mod record;
-
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use std::collections::BTreeMap;
 
-use measure::Plan;
-use record::{Record, SCHEMA_VERSION};
+use tak_cli::measure::{self, Plan};
+use tak_cli::notes;
+use tak_cli::record::{Record, SCHEMA_VERSION};
 
 #[derive(Parser)]
 #[command(name = "tak", version, about = "CLI performance, tracked", long_about = None)]
@@ -221,7 +218,10 @@ fn cmd_doctor() -> Result<()> {
     }
 
     match notes::fetch("origin") {
-        Ok(true) => println!("  ✓ notes fetch           refreshed {} from origin", notes::NOTES_REF),
+        Ok(true) => println!(
+            "  ✓ notes fetch           refreshed {} from origin",
+            notes::NOTES_REF
+        ),
         Ok(false) => println!(
             "  ! notes fetch           could not fetch {} (no remote, offline, or no data yet)",
             notes::NOTES_REF

--- a/src/record.rs
+++ b/src/record.rs
@@ -127,7 +127,11 @@ mod tests {
 
     #[test]
     fn one_bad_line_does_not_poison_the_note() {
-        let body = format!("{}\nnot json at all\n{}", rec().to_line().unwrap(), rec().to_line().unwrap());
+        let body = format!(
+            "{}\nnot json at all\n{}",
+            rec().to_line().unwrap(),
+            rec().to_line().unwrap()
+        );
         assert_eq!(parse_note(&body).len(), 2);
     }
 }

--- a/tests/counters.rs
+++ b/tests/counters.rs
@@ -23,9 +23,20 @@ fn valgrind_available() -> bool {
         .unwrap_or(false)
 }
 
-/// A command that exists on any unix and does a trivial, fixed amount of work.
+/// A command that exists on the host and does a trivial, fixed amount of work.
+///
+/// Absolute path on unix so no shell or PATH lookup is involved; on Windows
+/// there is no `/bin/echo`, and no cachegrind either, so the counter tests skip
+/// and only the wall-clock test needs a working subject.
 fn subject() -> Vec<String> {
-    vec!["/bin/echo".to_string(), "tak".to_string()]
+    #[cfg(unix)]
+    {
+        vec!["/bin/echo".to_string(), "tak".to_string()]
+    }
+    #[cfg(windows)]
+    {
+        vec!["cmd".to_string(), "/C".to_string(), "echo tak".to_string()]
+    }
 }
 
 #[test]

--- a/tests/counters.rs
+++ b/tests/counters.rs
@@ -1,0 +1,102 @@
+//! Integration tests for the deterministic-metric path.
+//!
+//! `measure::instructions` was written, unit-tested at the parser level, and
+//! then shipped without the cachegrind call ever executing once — valgrind was
+//! simply absent from the machine it was developed on. These tests exist so CI
+//! exercises the real subprocess, and so the determinism claim the whole project
+//! rests on is asserted rather than assumed.
+//!
+//! Every test skips cleanly when valgrind is unavailable, because that is the
+//! normal state on macOS and Windows.
+
+use std::process::{Command, Stdio};
+
+use tak_cli::measure::{self, Plan};
+
+fn valgrind_available() -> bool {
+    Command::new("valgrind")
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// A command that exists on any unix and does a trivial, fixed amount of work.
+fn subject() -> Vec<String> {
+    vec!["/bin/echo".to_string(), "tak".to_string()]
+}
+
+#[test]
+fn instructions_are_reported_when_valgrind_exists() {
+    if !valgrind_available() {
+        eprintln!("skipping: valgrind not installed");
+        return;
+    }
+    let n = measure::instructions(&subject())
+        .expect("cachegrind invocation failed")
+        .expect("valgrind present but no I refs parsed");
+
+    // A dynamically linked process cannot retire a trivially small number of
+    // instructions; anything tiny means we parsed the wrong thing.
+    assert!(n > 10_000, "implausibly low instruction count: {n}");
+}
+
+/// The claim the CI gate depends on: repeated runs of an identical command
+/// return identical counts.
+///
+/// Wall clock on the same machine varies by 4-20%; if this metric drifted at
+/// all, gating at 1% would be meaningless.
+#[test]
+fn instruction_counts_are_deterministic() {
+    if !valgrind_available() {
+        eprintln!("skipping: valgrind not installed");
+        return;
+    }
+    let cmd = subject();
+    let runs: Vec<u64> = (0..3)
+        .map(|_| {
+            measure::instructions(&cmd)
+                .expect("cachegrind invocation failed")
+                .expect("no I refs parsed")
+        })
+        .collect();
+
+    let min = *runs.iter().min().unwrap();
+    let max = *runs.iter().max().unwrap();
+    let spread = (max - min) as f64 / min as f64 * 100.0;
+
+    assert!(
+        spread < 0.1,
+        "instruction counts varied by {spread:.4}% across {runs:?} — \
+         the deterministic-gate premise does not hold on this platform"
+    );
+}
+
+/// Absence of valgrind must degrade to timing-only, never fail the run.
+#[test]
+fn missing_valgrind_is_not_an_error() {
+    if valgrind_available() {
+        eprintln!("skipping: valgrind is installed, cannot test its absence");
+        return;
+    }
+    let got = measure::instructions(&subject()).expect("must not error when valgrind is absent");
+    assert!(got.is_none());
+}
+
+/// Wall-clock measurement works everywhere, with or without counters.
+#[test]
+fn wall_clock_works_without_counters() {
+    let m = measure::wall(&Plan {
+        cmd: subject(),
+        warmup: 1,
+        runs: 3,
+    })
+    .expect("wall measurement failed");
+
+    assert_eq!(m["wall_n"], 3.0);
+    assert!(m["wall_min_ms"] <= m["wall_p50_ms"]);
+    assert!(m["wall_p50_ms"] <= m["wall_max_ms"]);
+    assert!(m["wall_min_ms"] > 0.0);
+}


### PR DESCRIPTION
## Why

`measure::instructions` had **never executed once**. Valgrind was absent from the machine it was written on, so only the stderr parser was unit-tested — the cachegrind subprocess itself was pure speculation.

Given the entire premise of this project is *"instruction counts are stable enough to gate CI on,"* that was the riskiest unverified thing in the repo.

## What it showed

Verified through `tak` itself, benchmarking `/bin/ls /usr` in a container:

| metric | quiet | 32-way CPU contention |
|---|---|---|
| `instructions` | 536124 | **536124** — byte-identical, 8/8 runs |
| `wall_min_ms` | 0.66 | 0.66 – 1.17 (**77% swing**) |

The premise holds.

## Changes

- **Split the crate into lib + bin** so integration tests can reach the measurement layer. `src/main.rs` becomes a thin binary over `tak_cli`.
- **`tests/counters.rs`** — asserts instruction counts are reported, that repeated runs differ by <0.1%, that a missing valgrind degrades rather than errors, and that wall clock works either way. Every test skips cleanly when valgrind is unavailable, which is the normal state on macOS and Windows.
- **`.github/workflows/ci.yml`** — installs valgrind so the counter path actually runs in CI and cannot silently stop executing again. Plus fmt, clippy `-D warnings`, and a macOS job that asserts the *degradation* path.
- **`docker/Dockerfile`** — there is no usable cachegrind on Apple Silicon, so a container is the only way to get counters there.
- README status updated to distinguish what runs from what does not.

## Verification

14 tests pass locally (counters skipped, no valgrind) and all 14 pass inside a valgrind container — the counter tests take 0.45s there versus 0.01s when skipped, confirming cachegrind genuinely ran rather than short-circuiting.

`cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` are clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly tests, CI, and crate layout; no production measurement or storage logic changes beyond wiring the binary to the library.
> 
> **Overview**
> Adds **integration coverage and CI** so the real `measure::instructions` / cachegrind subprocess runs in Linux CI instead of only parser-level unit tests.
> 
> The crate is split into **`tak_cli` lib + `tak` bin** so `tests/counters.rs` can assert instruction counts are reported, repeated runs differ by **&lt;0.1%**, missing valgrind degrades to `None` without error, and wall-clock measurement still works—each valgrind-dependent test **skips** when unavailable.
> 
> **`.github/workflows/ci.yml`** runs `fmt`, `clippy -D warnings`, and full tests on Ubuntu with **valgrind installed**, plus a **macOS** job for the no-valgrind path, and a **`final`** fan-in job for a single required check. **`docker/Dockerfile`** documents running `tak` with cachegrind on hosts without usable valgrind. README status and determinism notes are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6f341beed08904d0410ea80150b536a7a791c12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->