### PR TITLE
feat: tak backfill — bootstrap history from published release binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Measuring and storing work. Nothing reads the data back yet.
 - [x] instruction counts via cachegrind, degrading to timing-only where absent
 - [x] `refs/notes/tak` storage — `run --record`, `push`, `history`, `init`
 - [x] concurrent CI writers merge via `cat_sort_uniq`
-- [ ] `tak backfill --releases` — benchmark published release binaries to bootstrap history
+- [x] `tak backfill` — benchmark published release binaries to bootstrap history
 - [ ] `tak compare <ref>` — interleaved A/B against another revision
 - [ ] `bench.toml`
 - [ ] PR reporting

--- a/src/backfill.rs
+++ b/src/backfill.rs
@@ -14,8 +14,9 @@
 
 use anyhow::{Context, Result, bail};
 use serde::Deserialize;
+use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Asset {
@@ -35,40 +36,113 @@ pub struct Release {
     pub assets: Vec<Asset>,
 }
 
+/// GitHub's maximum, and the fewest round trips per page of history.
+const PER_PAGE: usize = 100;
+/// Bound the walk so a `--limit` larger than a project's history cannot spin.
+const MAX_PAGES: usize = 10;
+
+fn github_token() -> Option<String> {
+    std::env::var("GITHUB_TOKEN")
+        .or_else(|_| std::env::var("GH_TOKEN"))
+        .ok()
+        .filter(|t| !t.is_empty())
+}
+
+/// Run curl with every option supplied on stdin rather than as arguments.
+///
+/// A bearer token passed as `-H` lands in the process's argv, where any local
+/// process that can read `/proc` recovers it. `--config -` keeps it off the
+/// command line entirely.
+fn curl(url: &str, output: Option<&Path>, auth: bool) -> Result<Vec<u8>> {
+    let mut cfg = String::from("silent\nshow-error\nlocation\nfail\n");
+    cfg.push_str("header = \"User-Agent: tak\"\n");
+    if auth && let Some(token) = github_token() {
+        // curl's config format has no escape for `"` inside a quoted value, and
+        // GitHub tokens are ASCII-alphanumeric with `_`, so a token containing
+        // a quote is malformed rather than something to escape.
+        if token.contains(['"', '\n', '\r']) {
+            bail!("refusing to use a token containing quotes or newlines");
+        }
+        cfg.push_str(&format!("header = \"Authorization: Bearer {token}\"\n"));
+    }
+    if let Some(p) = output {
+        cfg.push_str(&format!("output = \"{}\"\n", p.display()));
+    }
+    cfg.push_str(&format!("url = \"{url}\"\n"));
+
+    let mut child = Command::new("curl")
+        .arg("--config")
+        .arg("-")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .context("failed to run curl — is it installed?")?;
+    child
+        .stdin
+        .take()
+        .context("curl stdin unavailable")?
+        .write_all(cfg.as_bytes())?;
+
+    let out = child.wait_with_output()?;
+    if !out.status.success() {
+        bail!(
+            "curl failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        );
+    }
+    Ok(out.stdout)
+}
+
 /// Releases for `repo` ("owner/name"), newest first, pre-releases excluded.
+///
+/// Pages until `limit` qualifying releases are found or the history runs out —
+/// a first page consisting mostly of pre-releases would otherwise silently
+/// return far fewer than asked for.
 ///
 /// Uses the GitHub API directly rather than mise-versions: that index only
 /// covers mise's curated registry, and backfill has to work for any project.
 pub fn list_releases(repo: &str, limit: usize) -> Result<Vec<Release>> {
-    let url = format!("https://api.github.com/repos/{repo}/releases?per_page=100");
-    let mut args = vec![
-        "-sSL".to_string(),
-        "-H".to_string(),
-        "Accept: application/vnd.github+json".to_string(),
-        "-H".to_string(),
-        "User-Agent: tak".to_string(),
-    ];
-    // Unauthenticated GitHub allows 60 requests/hour, which a backfill blows
-    // through immediately. Use a token when the environment offers one.
-    if let Ok(token) = std::env::var("GITHUB_TOKEN").or_else(|_| std::env::var("GH_TOKEN")) {
-        args.push("-H".to_string());
-        args.push(format!("Authorization: Bearer {token}"));
-    }
-    args.push(url);
+    let mut out: Vec<Release> = Vec::new();
 
-    let out = Command::new("curl")
-        .args(&args)
-        .output()
-        .context("failed to run curl — is it installed?")?;
-    if !out.status.success() {
-        bail!("curl failed listing releases for {repo}");
+    for page in 1..=MAX_PAGES {
+        let url =
+            format!("https://api.github.com/repos/{repo}/releases?per_page={PER_PAGE}&page={page}");
+        let body = curl(&url, None, true)?;
+        let batch: Vec<Release> =
+            serde_json::from_slice(&body).context("could not parse the GitHub releases API")?;
+        let exhausted = batch.len() < PER_PAGE;
+
+        out.extend(
+            batch
+                .into_iter()
+                .filter(|r| !r.prerelease && !r.assets.is_empty()),
+        );
+
+        if out.len() >= limit || exhausted {
+            break;
+        }
     }
 
-    let mut rels: Vec<Release> =
-        serde_json::from_slice(&out.stdout).context("could not parse the GitHub releases API")?;
-    rels.retain(|r| !r.prerelease && !r.assets.is_empty());
-    rels.truncate(limit);
-    Ok(rels)
+    out.truncate(limit);
+    Ok(out)
+}
+
+/// Does `haystack` contain `token` as a whole word?
+///
+/// Plain `contains` is wrong here: the Windows token `win` is a substring of
+/// `apple-darwin`, so a macOS tarball would satisfy the Windows filter and get
+/// measured on the wrong platform. Requiring non-alphanumeric boundaries makes
+/// `win` match `tool-win.zip` but not `darwin`, while `win64` still matches
+/// `tool-win64.zip` as its own token.
+fn contains_token(haystack: &str, token: &str) -> bool {
+    let h = haystack.as_bytes();
+    haystack.match_indices(token).any(|(i, _)| {
+        let before = i == 0 || !h[i - 1].is_ascii_alphanumeric();
+        let end = i + token.len();
+        let after = end == h.len() || !h[end].is_ascii_alphanumeric();
+        before && after
+    })
 }
 
 /// Platform tokens for the machine we are measuring on.
@@ -79,7 +153,7 @@ fn platform_tokens() -> (Vec<&'static str>, Vec<&'static str>) {
     let os: Vec<&str> = match std::env::consts::OS {
         "linux" => vec!["linux"],
         "macos" => vec!["darwin", "macos", "apple", "osx"],
-        "windows" => vec!["windows", "win"],
+        "windows" => vec!["windows", "win64", "win32", "win"],
         _ => vec![],
     };
     let arch: Vec<&str> = match std::env::consts::ARCH {
@@ -108,10 +182,10 @@ fn score_asset(name: &str, os: &[&str], arch: &[&str]) -> Option<i32> {
         return None;
     }
 
-    if !os.is_empty() && !os.iter().any(|t| n.contains(t)) {
+    if !os.is_empty() && !os.iter().any(|t| contains_token(&n, t)) {
         return None;
     }
-    if !arch.is_empty() && !arch.iter().any(|t| n.contains(t)) {
+    if !arch.is_empty() && !arch.iter().any(|t| contains_token(&n, t)) {
         return None;
     }
 
@@ -157,15 +231,14 @@ fn run(cmd: &mut Command, what: &str) -> Result<()> {
 /// Download `asset` into `dir`, unpack it, and return the path to `bin_name`.
 ///
 /// Handles tarballs, zips and bare executables — the three shapes essentially
-/// every CLI ships.
+/// every CLI ships. The download is authenticated for the same reason the
+/// listing is: a private repository's assets are not publicly readable, and
+/// failing here after listing succeeded would skip every release.
 pub fn fetch_binary(asset: &Asset, bin_name: &str, dir: &Path) -> Result<PathBuf> {
     std::fs::create_dir_all(dir)?;
     let archive = dir.join(&asset.name);
 
-    run(
-        Command::new("curl").args(["-sSL", "-o", &archive.to_string_lossy(), &asset.url]),
-        "curl",
-    )?;
+    curl(&asset.url, Some(&archive), true)?;
 
     let n = asset.name.to_lowercase();
     if n.ends_with(".tar.gz") || n.ends_with(".tgz") || n.ends_with(".tar.xz") {
@@ -213,10 +286,23 @@ fn make_executable(p: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Depth-limited search for `name`. Release archives nest one or two levels at
-/// most; a full walk risks wandering into a vendored tree.
+/// Names to accept for the executable.
+///
+/// Windows archives ship `tool.exe`, while `--bin` defaults to the repository
+/// name without a suffix, so an exact-match-only search skips every Windows
+/// release.
+fn binary_candidates(name: &str) -> Vec<String> {
+    let mut v = vec![name.to_string()];
+    if cfg!(windows) && !name.ends_with(".exe") {
+        v.push(format!("{name}.exe"));
+    }
+    v
+}
+
+/// Depth-limited search for the executable. Release archives nest one or two
+/// levels at most; a full walk risks wandering into a vendored tree.
 fn find_binary(dir: &Path, name: &str) -> Option<PathBuf> {
-    fn walk(dir: &Path, name: &str, depth: u32) -> Option<PathBuf> {
+    fn walk(dir: &Path, names: &[String], depth: u32) -> Option<PathBuf> {
         if depth > 3 {
             return None;
         }
@@ -226,18 +312,36 @@ fn find_binary(dir: &Path, name: &str) -> Option<PathBuf> {
             let p = e.path();
             if p.is_dir() {
                 dirs.push(p);
-            } else if p.file_name().and_then(|s| s.to_str()) == Some(name) {
+            } else if p
+                .file_name()
+                .and_then(|s| s.to_str())
+                .is_some_and(|f| names.iter().any(|n| n == f))
+            {
                 return Some(p);
             }
         }
-        dirs.into_iter().find_map(|d| walk(&d, name, depth + 1))
+        dirs.into_iter().find_map(|d| walk(&d, names, depth + 1))
     }
-    walk(dir, name, 0)
+    walk(dir, &binary_candidates(name), 0)
+}
+
+/// Whether the current directory is inside a git work tree.
+///
+/// Distinguishes "not in a repository" from "tag not fetched", which otherwise
+/// both surface as a missing tag and send people looking in the wrong place.
+pub fn in_git_repo() -> bool {
+    Command::new("git")
+        .args(["rev-parse", "--is-inside-work-tree"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
 }
 
 /// Resolve a release tag to the commit it points at, if the tag is available
 /// locally. Returns `None` rather than failing — a shallow clone legitimately
-/// has no tags, and the caller can still record against something else.
+/// has no tags, and the caller can still report that precisely.
 pub fn tag_commit(tag: &str) -> Option<String> {
     let out = Command::new("git")
         .args(["rev-parse", &format!("{tag}^{{commit}}")])
@@ -260,6 +364,7 @@ mod tests {
 
     const LINUX: [&str; 1] = ["linux"];
     const X64: [&str; 3] = ["x86_64", "amd64", "x64"];
+    const WINDOWS: [&str; 4] = ["windows", "win64", "win32", "win"];
 
     #[test]
     fn rejects_checksums_and_signatures() {
@@ -283,6 +388,28 @@ mod tests {
         // These need installing, not extracting, and would silently fail later.
         assert_eq!(score_asset("tool_1.2.3_amd64.deb", &LINUX, &X64), None);
         assert_eq!(score_asset("tool-1.2.3.x86_64.rpm", &LINUX, &X64), None);
+    }
+
+    /// `win` is a substring of `darwin`, so substring matching would let a macOS
+    /// tarball satisfy the Windows filter and be measured on the wrong platform.
+    #[test]
+    fn win_token_does_not_match_darwin() {
+        assert_eq!(
+            score_asset("tool-x86_64-apple-darwin.tar.gz", &WINDOWS, &X64),
+            None,
+            "a darwin asset must never satisfy the windows filter"
+        );
+        assert!(score_asset("tool-x86_64-win64.zip", &WINDOWS, &X64).is_some());
+        assert!(score_asset("tool-windows-amd64.zip", &WINDOWS, &X64).is_some());
+        assert!(score_asset("tool-win-x64.zip", &WINDOWS, &X64).is_some());
+    }
+
+    #[test]
+    fn token_matching_respects_word_boundaries() {
+        assert!(contains_token("tool-linux-amd64.tar.gz", "linux"));
+        assert!(contains_token("linux", "linux"));
+        assert!(!contains_token("apple-darwin", "win"));
+        assert!(!contains_token("mylinuxish", "linux"));
     }
 
     #[test]
@@ -339,6 +466,17 @@ mod tests {
         // Non-semver tags must survive untouched.
         assert_eq!(version_of("nightly"), "nightly");
         assert_eq!(version_of("lts-iron"), "lts-iron");
+    }
+
+    #[test]
+    fn windows_archives_may_carry_an_exe_suffix() {
+        let c = binary_candidates("mycli");
+        assert!(c.contains(&"mycli".to_string()));
+        if cfg!(windows) {
+            assert!(c.contains(&"mycli.exe".to_string()));
+        }
+        // An explicit .exe must not become mycli.exe.exe.
+        assert_eq!(binary_candidates("mycli.exe").len(), 1);
     }
 
     #[test]

--- a/src/backfill.rs
+++ b/src/backfill.rs
@@ -52,11 +52,15 @@ fn github_token() -> Option<String> {
         .filter(|t| !t.is_empty())
 }
 
-/// Run curl with every option supplied on stdin rather than as arguments.
+/// Run curl, keeping the bearer token off the command line.
 ///
-/// A bearer token passed as `-H` lands in the process's argv, where any local
-/// process that can read `/proc` recovers it. `--config -` keeps it off the
-/// command line entirely.
+/// The split matters. A token passed as `-H` lands in argv, where any local
+/// process reading `/proc` recovers it, so it goes over stdin via `--config -`.
+/// The URL and output path are *not* secret and go as ordinary arguments —
+/// which also sidesteps curl's config quoting, where a value containing `"` or
+/// a newline would otherwise close the quoted field and inject further
+/// directives. A crafted `browser_download_url` could then add its own `url =`
+/// line and receive the Authorization header meant for GitHub.
 fn curl(url: &str, output: Option<&Path>, auth: bool) -> Result<Vec<u8>> {
     let mut cfg = String::from("silent\nshow-error\nlocation\nfail\n");
     cfg.push_str("header = \"User-Agent: tak\"\n");
@@ -69,14 +73,21 @@ fn curl(url: &str, output: Option<&Path>, auth: bool) -> Result<Vec<u8>> {
         }
         cfg.push_str(&format!("header = \"Authorization: Bearer {token}\"\n"));
     }
-    if let Some(p) = output {
-        cfg.push_str(&format!("output = \"{}\"\n", p.display()));
-    }
-    cfg.push_str(&format!("url = \"{url}\"\n"));
 
-    let mut child = Command::new("curl")
-        .arg("--config")
-        .arg("-")
+    // Only ever talk to https endpoints: a `http://` or `file://` redirect
+    // target would send the header in clear or read local files.
+    if !url.starts_with("https://") {
+        bail!("refusing a non-https URL: {url}");
+    }
+
+    let mut cmd = Command::new("curl");
+    cmd.arg("--config").arg("-");
+    if let Some(p) = output {
+        cmd.arg("-o").arg(p);
+    }
+    cmd.arg("--").arg(url);
+
+    let mut child = cmd
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -261,6 +272,10 @@ fn run(cmd: &mut Command, what: &str) -> Result<()> {
 /// listing is: a private repository's assets are not publicly readable, and
 /// failing here after listing succeeded would skip every release.
 pub fn fetch_binary(asset: &Asset, bin_name: &str, dir: &Path) -> Result<PathBuf> {
+    // Start clean. Reusing a populated directory risks `find_binary` picking up
+    // an executable left by an earlier release and attributing its measurement
+    // to the wrong tag.
+    std::fs::remove_dir_all(dir).ok();
     std::fs::create_dir_all(dir)?;
     // Asset names come from the API and are not trusted: `../../x` would escape
     // the per-release directory and write wherever it liked.
@@ -339,11 +354,20 @@ fn safe_component(name: &str) -> Result<String> {
     Ok(base.to_string())
 }
 
+/// A filesystem-safe, collision-free directory name for a release.
+///
+/// Sanitising alone is not enough: tags may contain `/` (`release/1.0`), and
+/// mapping both `v1/0` and `v1_0` to `v1_0` would let two releases share a
+/// directory. The index keeps them distinct.
+pub fn release_dir_name(index: usize, tag: &str) -> String {
+    format!("{index:04}-{}", safe_dir_name(tag))
+}
+
 /// A filesystem-safe directory name for a release tag.
 ///
 /// Tags may contain `/` (`release/1.0`) and are otherwise arbitrary, so anything
 /// outside a conservative set becomes `_`.
-pub fn safe_dir_name(tag: &str) -> String {
+fn safe_dir_name(tag: &str) -> String {
     let s: String = tag
         .chars()
         .map(|c| {
@@ -566,6 +590,21 @@ mod tests {
         }
         // An explicit .exe must not become mycli.exe.exe.
         assert_eq!(binary_candidates("mycli.exe").len(), 1);
+    }
+
+    #[test]
+    fn release_dirs_never_collide() {
+        // Sanitising alone maps both of these to `v1_0`.
+        assert_ne!(
+            release_dir_name(0, "v1/0"),
+            release_dir_name(1, "v1_0"),
+            "distinct releases must not share a work directory"
+        );
+        assert_eq!(release_dir_name(7, "v1.2.3"), "0007-v1.2.3");
+        // Path separators must not survive into the name.
+        assert!(!release_dir_name(0, "release/1.0").contains('/'));
+        // A tag of only punctuation still yields something usable.
+        assert!(!release_dir_name(0, "...").is_empty());
     }
 
     #[test]

--- a/src/backfill.rs
+++ b/src/backfill.rs
@@ -32,6 +32,10 @@ pub struct Release {
     pub published_at: Option<String>,
     #[serde(default)]
     pub prerelease: bool,
+    /// Drafts are visible to authenticated requests and are not published
+    /// artefacts, so benchmarking one would record a version nobody can install.
+    #[serde(default)]
+    pub draft: bool,
     #[serde(default)]
     pub assets: Vec<Asset>,
 }
@@ -116,16 +120,30 @@ pub fn list_releases(repo: &str, limit: usize) -> Result<Vec<Release>> {
         out.extend(
             batch
                 .into_iter()
-                .filter(|r| !r.prerelease && !r.assets.is_empty()),
+                .filter(|r| !r.prerelease && !r.draft && !r.assets.is_empty()),
         );
 
-        if out.len() >= limit || exhausted {
+        if out.len() >= limit {
             break;
+        }
+        if exhausted {
+            return Ok(finish(out, limit));
+        }
+        if page == MAX_PAGES {
+            eprintln!(
+                "warning: stopped after {MAX_PAGES} pages with {} of {limit} releases; \
+                 older releases exist but were not fetched",
+                out.len()
+            );
         }
     }
 
-    out.truncate(limit);
-    Ok(out)
+    Ok(finish(out, limit))
+}
+
+fn finish(mut v: Vec<Release>, limit: usize) -> Vec<Release> {
+    v.truncate(limit);
+    v
 }
 
 /// Does `haystack` contain `token` as a whole word?
@@ -172,10 +190,18 @@ fn score_asset(name: &str, os: &[&str], arch: &[&str]) -> Option<i32> {
     let n = name.to_lowercase();
 
     // Never benchmark checksums, signatures or source archives.
-    const REJECT: [&str; 8] = [
-        ".sha256", ".sha512", ".asc", ".sig", ".pem", ".sbom", "sources", ".deb",
+    const REJECT: [&str; 7] = [
+        ".sha256", ".sha512", ".asc", ".sig", ".pem", ".sbom", ".deb",
     ];
     if REJECT.iter().any(|r| n.contains(r)) {
+        return None;
+    }
+    // Source drops contain no executable. Matched as whole words so a tool
+    // legitimately named e.g. `resource-cli` is not rejected.
+    if ["source", "sources", "src"]
+        .iter()
+        .any(|t| contains_token(&n, t))
+    {
         return None;
     }
     if n.ends_with(".rpm") || n.ends_with(".msi") || n.ends_with(".pkg") {
@@ -236,12 +262,15 @@ fn run(cmd: &mut Command, what: &str) -> Result<()> {
 /// failing here after listing succeeded would skip every release.
 pub fn fetch_binary(asset: &Asset, bin_name: &str, dir: &Path) -> Result<PathBuf> {
     std::fs::create_dir_all(dir)?;
-    let archive = dir.join(&asset.name);
+    // Asset names come from the API and are not trusted: `../../x` would escape
+    // the per-release directory and write wherever it liked.
+    let archive = dir.join(safe_component(&asset.name)?);
 
     curl(&asset.url, Some(&archive), true)?;
 
     let n = asset.name.to_lowercase();
-    if n.ends_with(".tar.gz") || n.ends_with(".tgz") || n.ends_with(".tar.xz") {
+    if TAR_SUFFIXES.iter().any(|e| n.ends_with(e)) {
+        // `tar -xf` sniffs the compression, so gz/xz/bz2/zst all work here.
         run(
             Command::new("tar").args([
                 "-xf",
@@ -261,16 +290,76 @@ pub fn fetch_binary(asset: &Asset, bin_name: &str, dir: &Path) -> Result<PathBuf
             ]),
             "unzip",
         )?;
-    } else {
-        // A bare binary: the download is the artefact.
+    } else if is_bare_binary(&n) {
+        // The download is the artefact.
         make_executable(&archive)?;
         return Ok(archive);
+    } else {
+        // Anything else would previously have been *executed* as if it were a
+        // binary. Skipping loudly beats benchmarking a tarball.
+        bail!("unsupported archive format: {}", asset.name);
     }
 
     let found = find_binary(dir, bin_name)
         .with_context(|| format!("no `{bin_name}` inside {}", asset.name))?;
     make_executable(&found)?;
     Ok(found)
+}
+
+/// Archive suffixes `tar` can unpack unaided.
+const TAR_SUFFIXES: [&str; 7] = [
+    ".tar.gz", ".tgz", ".tar.xz", ".txz", ".tar.bz2", ".tar.zst", ".tar",
+];
+
+/// Is this plausibly a bare executable rather than an archive?
+///
+/// Conservative on purpose: an unrecognised extension is treated as an archive
+/// we cannot open, not as something safe to run.
+fn is_bare_binary(lower_name: &str) -> bool {
+    if lower_name.ends_with(".exe") {
+        return true;
+    }
+    // No extension at all — the usual shape for a raw unix binary.
+    !Path::new(lower_name)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .is_some_and(|f| f.contains('.'))
+}
+
+/// Reduce an untrusted name to a single safe path component.
+///
+/// `Path::join` with a value containing `..` or separators escapes the intended
+/// directory, and both asset names and tags come from the GitHub API.
+fn safe_component(name: &str) -> Result<String> {
+    let base = Path::new(name)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .filter(|s| !s.is_empty() && *s != "." && *s != "..")
+        .with_context(|| format!("unusable name from the API: {name:?}"))?;
+    Ok(base.to_string())
+}
+
+/// A filesystem-safe directory name for a release tag.
+///
+/// Tags may contain `/` (`release/1.0`) and are otherwise arbitrary, so anything
+/// outside a conservative set becomes `_`.
+pub fn safe_dir_name(tag: &str) -> String {
+    let s: String = tag
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let trimmed = s.trim_matches('.');
+    if trimmed.is_empty() {
+        "release".to_string()
+    } else {
+        trimmed.to_string()
+    }
 }
 
 fn make_executable(p: &Path) -> Result<()> {

--- a/src/backfill.rs
+++ b/src/backfill.rs
@@ -62,7 +62,13 @@ fn github_token() -> Option<String> {
 /// directives. A crafted `browser_download_url` could then add its own `url =`
 /// line and receive the Authorization header meant for GitHub.
 fn curl(url: &str, output: Option<&Path>, auth: bool) -> Result<Vec<u8>> {
-    let mut cfg = String::from("silent\nshow-error\nlocation\nfail\n");
+    // `proto`/`proto-redir` are the load-bearing part: `location` follows
+    // redirects, and without pinning the redirect protocol a downgrade to
+    // http:// on the same host would carry the Authorization header in clear.
+    // Checking only the initial URL is not enough.
+    let mut cfg = String::from(
+        "silent\nshow-error\nlocation\nfail\nproto = \"=https\"\nproto-redir = \"=https\"\n",
+    );
     cfg.push_str("header = \"User-Agent: tak\"\n");
     if auth && let Some(token) = github_token() {
         // curl's config format has no escape for `"` inside a quoted value, and

--- a/src/backfill.rs
+++ b/src/backfill.rs
@@ -1,0 +1,356 @@
+//! Backfill history from published release binaries.
+//!
+//! A new adopter's first chart is empty, and an empty chart persuades nobody.
+//! Rather than rebuilding a project at a hundred historical commits — hours of
+//! compute, and impossible for anyone without a reproducible build — this
+//! downloads the binaries the project already published and measures those.
+//! Minutes, not hours, and it works for projects whose old commits no longer
+//! build at all.
+//!
+//! Network and archive handling shell out to `curl` and `tar`/`unzip` for the
+//! same reason [`crate::notes`] shells out to `git`: proxies, CA bundles and
+//! credential helpers are already solved there, and the dependency tree stays
+//! small.
+
+use anyhow::{Context, Result, bail};
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Asset {
+    pub name: String,
+    #[serde(rename = "browser_download_url")]
+    pub url: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Release {
+    #[serde(rename = "tag_name")]
+    pub tag: String,
+    pub published_at: Option<String>,
+    #[serde(default)]
+    pub prerelease: bool,
+    #[serde(default)]
+    pub assets: Vec<Asset>,
+}
+
+/// Releases for `repo` ("owner/name"), newest first, pre-releases excluded.
+///
+/// Uses the GitHub API directly rather than mise-versions: that index only
+/// covers mise's curated registry, and backfill has to work for any project.
+pub fn list_releases(repo: &str, limit: usize) -> Result<Vec<Release>> {
+    let url = format!("https://api.github.com/repos/{repo}/releases?per_page=100");
+    let mut args = vec![
+        "-sSL".to_string(),
+        "-H".to_string(),
+        "Accept: application/vnd.github+json".to_string(),
+        "-H".to_string(),
+        "User-Agent: tak".to_string(),
+    ];
+    // Unauthenticated GitHub allows 60 requests/hour, which a backfill blows
+    // through immediately. Use a token when the environment offers one.
+    if let Ok(token) = std::env::var("GITHUB_TOKEN").or_else(|_| std::env::var("GH_TOKEN")) {
+        args.push("-H".to_string());
+        args.push(format!("Authorization: Bearer {token}"));
+    }
+    args.push(url);
+
+    let out = Command::new("curl")
+        .args(&args)
+        .output()
+        .context("failed to run curl — is it installed?")?;
+    if !out.status.success() {
+        bail!("curl failed listing releases for {repo}");
+    }
+
+    let mut rels: Vec<Release> =
+        serde_json::from_slice(&out.stdout).context("could not parse the GitHub releases API")?;
+    rels.retain(|r| !r.prerelease && !r.assets.is_empty());
+    rels.truncate(limit);
+    Ok(rels)
+}
+
+/// Platform tokens for the machine we are measuring on.
+///
+/// Measuring a darwin binary on linux would be meaningless, so asset selection
+/// is strict about the OS and only flexible about spelling.
+fn platform_tokens() -> (Vec<&'static str>, Vec<&'static str>) {
+    let os: Vec<&str> = match std::env::consts::OS {
+        "linux" => vec!["linux"],
+        "macos" => vec!["darwin", "macos", "apple", "osx"],
+        "windows" => vec!["windows", "win"],
+        _ => vec![],
+    };
+    let arch: Vec<&str> = match std::env::consts::ARCH {
+        "x86_64" => vec!["x86_64", "amd64", "x64"],
+        "aarch64" => vec!["aarch64", "arm64"],
+        _ => vec![],
+    };
+    (os, arch)
+}
+
+/// Score an asset for this platform. `None` means "definitely not usable here".
+///
+/// Deliberately conservative: a wrong choice produces numbers that look real and
+/// are meaningless, which is worse than backfilling nothing.
+fn score_asset(name: &str, os: &[&str], arch: &[&str]) -> Option<i32> {
+    let n = name.to_lowercase();
+
+    // Never benchmark checksums, signatures or source archives.
+    const REJECT: [&str; 8] = [
+        ".sha256", ".sha512", ".asc", ".sig", ".pem", ".sbom", "sources", ".deb",
+    ];
+    if REJECT.iter().any(|r| n.contains(r)) {
+        return None;
+    }
+    if n.ends_with(".rpm") || n.ends_with(".msi") || n.ends_with(".pkg") {
+        return None;
+    }
+
+    if !os.is_empty() && !os.iter().any(|t| n.contains(t)) {
+        return None;
+    }
+    if !arch.is_empty() && !arch.iter().any(|t| n.contains(t)) {
+        return None;
+    }
+
+    let mut score = 100;
+    // musl is statically linked, so it runs on any distro including the slim
+    // container images this is most often executed in.
+    if n.contains("musl") {
+        score += 20;
+    }
+    if n.ends_with(".tar.gz") || n.ends_with(".tgz") {
+        score += 10;
+    } else if n.ends_with(".tar.xz") {
+        score += 8;
+    } else if n.ends_with(".zip") {
+        score += 5;
+    }
+    Some(score)
+}
+
+/// Best asset for the current platform, or `None` if nothing matches.
+pub fn pick_asset(assets: &[Asset]) -> Option<&Asset> {
+    let (os, arch) = platform_tokens();
+    assets
+        .iter()
+        .filter_map(|a| score_asset(&a.name, &os, &arch).map(|s| (s, a)))
+        .max_by_key(|(s, _)| *s)
+        .map(|(_, a)| a)
+}
+
+fn run(cmd: &mut Command, what: &str) -> Result<()> {
+    let out = cmd
+        .output()
+        .with_context(|| format!("failed to run {what}"))?;
+    if !out.status.success() {
+        bail!(
+            "{what} failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        );
+    }
+    Ok(())
+}
+
+/// Download `asset` into `dir`, unpack it, and return the path to `bin_name`.
+///
+/// Handles tarballs, zips and bare executables — the three shapes essentially
+/// every CLI ships.
+pub fn fetch_binary(asset: &Asset, bin_name: &str, dir: &Path) -> Result<PathBuf> {
+    std::fs::create_dir_all(dir)?;
+    let archive = dir.join(&asset.name);
+
+    run(
+        Command::new("curl").args(["-sSL", "-o", &archive.to_string_lossy(), &asset.url]),
+        "curl",
+    )?;
+
+    let n = asset.name.to_lowercase();
+    if n.ends_with(".tar.gz") || n.ends_with(".tgz") || n.ends_with(".tar.xz") {
+        run(
+            Command::new("tar").args([
+                "-xf",
+                &archive.to_string_lossy(),
+                "-C",
+                &dir.to_string_lossy(),
+            ]),
+            "tar",
+        )?;
+    } else if n.ends_with(".zip") {
+        run(
+            Command::new("unzip").args([
+                "-oq",
+                &archive.to_string_lossy(),
+                "-d",
+                &dir.to_string_lossy(),
+            ]),
+            "unzip",
+        )?;
+    } else {
+        // A bare binary: the download is the artefact.
+        make_executable(&archive)?;
+        return Ok(archive);
+    }
+
+    let found = find_binary(dir, bin_name)
+        .with_context(|| format!("no `{bin_name}` inside {}", asset.name))?;
+    make_executable(&found)?;
+    Ok(found)
+}
+
+fn make_executable(p: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(p)?.permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(p, perms)?;
+    }
+    #[cfg(not(unix))]
+    let _ = p;
+    Ok(())
+}
+
+/// Depth-limited search for `name`. Release archives nest one or two levels at
+/// most; a full walk risks wandering into a vendored tree.
+fn find_binary(dir: &Path, name: &str) -> Option<PathBuf> {
+    fn walk(dir: &Path, name: &str, depth: u32) -> Option<PathBuf> {
+        if depth > 3 {
+            return None;
+        }
+        let entries = std::fs::read_dir(dir).ok()?;
+        let mut dirs = Vec::new();
+        for e in entries.flatten() {
+            let p = e.path();
+            if p.is_dir() {
+                dirs.push(p);
+            } else if p.file_name().and_then(|s| s.to_str()) == Some(name) {
+                return Some(p);
+            }
+        }
+        dirs.into_iter().find_map(|d| walk(&d, name, depth + 1))
+    }
+    walk(dir, name, 0)
+}
+
+/// Resolve a release tag to the commit it points at, if the tag is available
+/// locally. Returns `None` rather than failing — a shallow clone legitimately
+/// has no tags, and the caller can still record against something else.
+pub fn tag_commit(tag: &str) -> Option<String> {
+    let out = Command::new("git")
+        .args(["rev-parse", &format!("{tag}^{{commit}}")])
+        .output()
+        .ok()?;
+    out.status
+        .success()
+        .then(|| String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+/// Strip a leading `v` for display. Deliberately does no other normalisation —
+/// tool version strings are frequently not semver and must stay opaque.
+pub fn version_of(tag: &str) -> &str {
+    tag.strip_prefix('v').unwrap_or(tag)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const LINUX: [&str; 1] = ["linux"];
+    const X64: [&str; 3] = ["x86_64", "amd64", "x64"];
+
+    #[test]
+    fn rejects_checksums_and_signatures() {
+        for n in [
+            "tool-linux-x86_64.tar.gz.sha256",
+            "tool-linux-x86_64.tar.gz.asc",
+            "tool.sbom.json",
+        ] {
+            assert_eq!(score_asset(n, &LINUX, &X64), None, "{n} should be rejected");
+        }
+    }
+
+    #[test]
+    fn rejects_other_platforms() {
+        assert_eq!(score_asset("tool-darwin-arm64.tar.gz", &LINUX, &X64), None);
+        assert_eq!(score_asset("tool-linux-aarch64.tar.gz", &LINUX, &X64), None);
+    }
+
+    #[test]
+    fn rejects_distro_packages() {
+        // These need installing, not extracting, and would silently fail later.
+        assert_eq!(score_asset("tool_1.2.3_amd64.deb", &LINUX, &X64), None);
+        assert_eq!(score_asset("tool-1.2.3.x86_64.rpm", &LINUX, &X64), None);
+    }
+
+    #[test]
+    fn prefers_musl_over_gnu() {
+        let musl = score_asset("tool-x86_64-unknown-linux-musl.tar.gz", &LINUX, &X64).unwrap();
+        let gnu = score_asset("tool-x86_64-unknown-linux-gnu.tar.gz", &LINUX, &X64).unwrap();
+        assert!(musl > gnu, "musl {musl} should outrank gnu {gnu}");
+    }
+
+    #[test]
+    fn prefers_tarball_over_zip() {
+        let tgz = score_asset("tool-linux-amd64.tar.gz", &LINUX, &X64).unwrap();
+        let zip = score_asset("tool-linux-amd64.zip", &LINUX, &X64).unwrap();
+        assert!(tgz > zip);
+    }
+
+    #[test]
+    fn accepts_common_arch_spellings() {
+        for n in [
+            "tool-linux-x86_64.tar.gz",
+            "tool-linux-amd64.tar.gz",
+            "tool-linux-x64.tar.gz",
+        ] {
+            assert!(score_asset(n, &LINUX, &X64).is_some(), "{n} should match");
+        }
+    }
+
+    #[test]
+    fn pick_asset_chooses_the_best_candidate() {
+        let assets: Vec<Asset> = [
+            "tool-x86_64-apple-darwin.tar.gz",
+            "tool-x86_64-unknown-linux-gnu.tar.gz",
+            "tool-x86_64-unknown-linux-musl.tar.gz",
+            "tool-x86_64-unknown-linux-musl.tar.gz.sha256",
+        ]
+        .iter()
+        .map(|n| Asset {
+            name: n.to_string(),
+            url: format!("https://example.invalid/{n}"),
+        })
+        .collect();
+
+        // Only meaningful on the platform whose tokens the test asserts.
+        if std::env::consts::OS == "linux" && std::env::consts::ARCH == "x86_64" {
+            let got = pick_asset(&assets).expect("something should match");
+            assert_eq!(got.name, "tool-x86_64-unknown-linux-musl.tar.gz");
+        }
+    }
+
+    #[test]
+    fn version_strips_only_the_v_prefix() {
+        assert_eq!(version_of("v1.2.3"), "1.2.3");
+        assert_eq!(version_of("2024.01.15"), "2024.01.15");
+        // Non-semver tags must survive untouched.
+        assert_eq!(version_of("nightly"), "nightly");
+        assert_eq!(version_of("lts-iron"), "lts-iron");
+    }
+
+    #[test]
+    fn finds_a_nested_binary() {
+        let dir = std::env::temp_dir().join(format!("tak-find-{}", std::process::id()));
+        let nested = dir.join("tool-1.0").join("bin");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(nested.join("mycli"), b"#!/bin/sh\n").unwrap();
+
+        assert_eq!(find_binary(&dir, "mycli"), Some(nested.join("mycli")));
+        assert_eq!(find_binary(&dir, "absent"), None);
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/src/backfill.rs
+++ b/src/backfill.rs
@@ -225,10 +225,18 @@ fn score_asset(name: &str, os: &[&str], arch: &[&str]) -> Option<i32> {
         return None;
     }
 
-    if !os.is_empty() && !os.iter().any(|t| contains_token(&n, t)) {
+    // An unrecognised host (FreeBSD, riscv64, …) leaves the token list empty.
+    // Skipping the filter in that case is the opposite of conservative: it lets
+    // a linux-x86_64 tarball match on a machine that cannot run it, and a
+    // wrong-platform binary either fails to exec or, worse, runs and measures
+    // something meaningless. Refusing to guess is the right answer.
+    if os.is_empty() || arch.is_empty() {
         return None;
     }
-    if !arch.is_empty() && !arch.iter().any(|t| contains_token(&n, t)) {
+    if !os.iter().any(|t| contains_token(&n, t)) {
+        return None;
+    }
+    if !arch.iter().any(|t| contains_token(&n, t)) {
         return None;
     }
 
@@ -529,6 +537,23 @@ mod tests {
         assert!(contains_token("linux", "linux"));
         assert!(!contains_token("apple-darwin", "win"));
         assert!(!contains_token("mylinuxish", "linux"));
+    }
+
+    /// An empty token list means "we do not know this host", which must reject
+    /// rather than match everything.
+    #[test]
+    fn an_unknown_host_matches_nothing() {
+        let none: [&str; 0] = [];
+        assert_eq!(
+            score_asset("tool-linux-x86_64.tar.gz", &none, &X64),
+            None,
+            "unknown OS must not accept a linux asset"
+        );
+        assert_eq!(
+            score_asset("tool-linux-x86_64.tar.gz", &LINUX, &none),
+            None,
+            "unknown arch must not accept an x86_64 asset"
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 //! by integration tests. `measure::instructions` in particular went a long time
 //! written-but-never-executed, which is exactly the failure this guards against.
 
+pub mod backfill;
 pub mod measure;
 pub mod notes;
 pub mod record;

--- a/src/main.rs
+++ b/src/main.rs
@@ -351,14 +351,14 @@ fn cmd_backfill(
     let mut recorded = 0usize;
     let mut skipped = 0usize;
 
-    for rel in &releases {
+    for (i, rel) in releases.iter().enumerate() {
         let Some(asset) = backfill::pick_asset(&rel.assets) else {
             println!("  {:<14} skipped — no asset for this platform", rel.tag);
             skipped += 1;
             continue;
         };
 
-        let dir = workdir.join(backfill::safe_dir_name(&rel.tag));
+        let dir = workdir.join(backfill::release_dir_name(i, &rel.tag));
         let path = match backfill::fetch_binary(asset, &bin, &dir) {
             Ok(p) => p,
             Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use std::collections::BTreeMap;
 
+use tak_cli::backfill;
 use tak_cli::measure::{self, Plan};
 use tak_cli::notes;
 use tak_cli::record::{Record, SCHEMA_VERSION};
@@ -58,6 +59,36 @@ enum Cmd {
     Init {
         #[arg(long, default_value = "origin")]
         remote: String,
+    },
+    /// Benchmark published release binaries to bootstrap history.
+    ///
+    /// A new adopter's first chart is empty. Rather than rebuilding a project at
+    /// a hundred historical commits, download what it already published.
+    Backfill {
+        /// Repository to pull releases from, as "owner/name". Defaults to the
+        /// `origin` remote of the current repository.
+        #[arg(long)]
+        repo: Option<String>,
+        /// Executable name to look for inside each release archive. Defaults to
+        /// the repository name.
+        #[arg(long)]
+        bin: Option<String>,
+        /// Arguments passed to the downloaded binary, after `--`.
+        /// Defaults to `--version`, which every CLI answers cheaply.
+        #[arg(last = true)]
+        args: Vec<String>,
+        /// Name to record measurements under.
+        #[arg(long, default_value = "release")]
+        bench: String,
+        /// Most recent releases to measure.
+        #[arg(long, default_value_t = 20)]
+        limit: usize,
+        /// Timed runs per release.
+        #[arg(long, default_value_t = 10)]
+        runs: u32,
+        /// Measure but do not write to refs/notes/tak.
+        #[arg(long)]
+        dry_run: bool,
     },
     /// Diagnose the git-notes plumbing.
     Doctor,
@@ -233,6 +264,139 @@ fn cmd_doctor() -> Result<()> {
     Ok(())
 }
 
+/// Infer "owner/name" from the `origin` remote.
+fn repo_from_origin() -> Option<String> {
+    let out = std::process::Command::new("git")
+        .args(["remote", "get-url", "origin"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let url = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    // Handles https://github.com/o/r(.git) and git@github.com:o/r(.git).
+    let tail = url.rsplit_once("github.com").map(|(_, t)| t)?;
+    let slug = tail.trim_start_matches([':', '/']).trim_end_matches(".git");
+    (slug.matches('/').count() == 1).then(|| slug.to_string())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn cmd_backfill(
+    repo: Option<String>,
+    bin: Option<String>,
+    args: Vec<String>,
+    bench: String,
+    limit: usize,
+    runs: u32,
+    dry_run: bool,
+) -> Result<()> {
+    let repo = repo
+        .or_else(repo_from_origin)
+        .context("could not infer the repository — pass --repo owner/name")?;
+    let bin = bin.unwrap_or_else(|| repo.rsplit('/').next().unwrap_or(&repo).to_string());
+    let args = if args.is_empty() {
+        vec!["--version".to_string()]
+    } else {
+        args
+    };
+
+    let releases = backfill::list_releases(&repo, limit)?;
+    if releases.is_empty() {
+        println!("no releases with downloadable assets found for {repo}");
+        return Ok(());
+    }
+    println!("{} release(s) from {repo}\n", releases.len());
+
+    let workdir = std::env::temp_dir().join(format!("tak-backfill-{}", std::process::id()));
+    let mut recorded = 0usize;
+    let mut skipped = 0usize;
+
+    for rel in &releases {
+        let Some(asset) = backfill::pick_asset(&rel.assets) else {
+            println!("  {:<14} skipped — no asset for this platform", rel.tag);
+            skipped += 1;
+            continue;
+        };
+
+        let dir = workdir.join(&rel.tag);
+        let path = match backfill::fetch_binary(asset, &bin, &dir) {
+            Ok(p) => p,
+            Err(e) => {
+                println!("  {:<14} skipped — {e}", rel.tag);
+                skipped += 1;
+                continue;
+            }
+        };
+
+        let mut cmd = vec![path.to_string_lossy().to_string()];
+        cmd.extend(args.iter().cloned());
+
+        let plan = Plan {
+            cmd: cmd.clone(),
+            warmup: 2,
+            runs,
+        };
+        let mut metrics = match measure::wall(&plan) {
+            Ok(m) => m,
+            Err(e) => {
+                println!("  {:<14} skipped — {e}", rel.tag);
+                skipped += 1;
+                continue;
+            }
+        };
+        if let Ok(Some(n)) = measure::instructions(&cmd) {
+            metrics.insert("instructions".into(), n as f64);
+        }
+
+        let ins = metrics
+            .get("instructions")
+            .map(|v| format!("{v:>14.0}"))
+            .unwrap_or_else(|| format!("{:>14}", "-"));
+        println!(
+            "  {:<14} wall_min {:>8.2}ms   instructions {ins}",
+            rel.tag, metrics["wall_min_ms"]
+        );
+
+        if dry_run {
+            continue;
+        }
+
+        // Attach to the tagged commit so the series lands on the real timeline.
+        // A shallow clone has no tags, which is a skip rather than an error.
+        let Some(sha) = backfill::tag_commit(&rel.tag) else {
+            println!("                 not recorded — tag not present locally");
+            skipped += 1;
+            continue;
+        };
+
+        let rec = Record {
+            v: SCHEMA_VERSION,
+            bench: bench.clone(),
+            tool: bin.clone(),
+            version: Some(backfill::version_of(&rel.tag).to_string()),
+            runner: runner_class(),
+            // The release's own date, not now: this is when the code existed.
+            ts: rel.published_at.clone().unwrap_or_else(now_rfc3339),
+            metrics,
+        };
+        notes::append(&sha, &[rec])?;
+        recorded += 1;
+    }
+
+    std::fs::remove_dir_all(&workdir).ok();
+
+    if dry_run {
+        println!("\n  dry run — nothing written");
+    } else {
+        println!(
+            "\n  recorded {recorded}, skipped {skipped} → {}",
+            notes::NOTES_REF
+        );
+        println!("  push with: tak push");
+    }
+    Ok(())
+}
+
 fn main() -> Result<()> {
     match Cli::parse().cmd {
         Cmd::Run {
@@ -257,6 +421,15 @@ fn main() -> Result<()> {
             );
             Ok(())
         }
+        Cmd::Backfill {
+            repo,
+            bin,
+            args,
+            bench,
+            limit,
+            runs,
+            dry_run,
+        } => cmd_backfill(repo, bin, args, bench, limit, runs, dry_run),
         Cmd::Doctor => cmd_doctor(),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,8 +153,8 @@ fn cmd_run(
     let mut metrics: BTreeMap<String, f64> = measure::wall(&plan)?;
 
     if !no_counters {
-        match measure::instructions(&cmd)? {
-            Some(c) => {
+        match measure::instructions(&cmd) {
+            Ok(Some(c)) => {
                 metrics.insert("instructions".into(), c.min as f64);
                 if c.is_suspect() {
                     eprintln!(
@@ -168,11 +168,14 @@ fn cmd_run(
                     );
                 }
             }
-            None => eprintln!(
+            Ok(None) => eprintln!(
                 "note: valgrind not found — recording timing only. \
                  Instruction counts are the only gate-able metric; on macOS/Windows \
                  run tak in a Linux container to get them."
             ),
+            // Valgrind exists but the measurement failed. Say so rather than
+            // blaming a missing install, and keep the timing we did collect.
+            Err(e) => eprintln!("warning: instruction counting failed: {e}"),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@
 //!
 //! Experimental. See README.md, which asks you to use hyperfine instead.
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use clap::{Parser, Subcommand};
 use std::collections::BTreeMap;
 
@@ -300,6 +300,15 @@ fn cmd_backfill(
         args
     };
 
+    // Fail before spending minutes downloading and measuring, and so that a
+    // missing tag later means exactly that rather than "not in a repository".
+    if !dry_run && !backfill::in_git_repo() {
+        bail!(
+            "not inside a git repository — measurements are recorded against tagged \
+             commits. Run from a clone of {repo}, or pass --dry-run."
+        );
+    }
+
     let releases = backfill::list_releases(&repo, limit)?;
     if releases.is_empty() {
         println!("no releases with downloadable assets found for {repo}");
@@ -364,7 +373,10 @@ fn cmd_backfill(
         // Attach to the tagged commit so the series lands on the real timeline.
         // A shallow clone has no tags, which is a skip rather than an error.
         let Some(sha) = backfill::tag_commit(&rel.tag) else {
-            println!("                 not recorded — tag not present locally");
+            println!(
+                "                 not recorded — tag {} not present locally (try `git fetch --tags`)",
+                rel.tag
+            );
             skipped += 1;
             continue;
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,8 +154,19 @@ fn cmd_run(
 
     if !no_counters {
         match measure::instructions(&cmd)? {
-            Some(n) => {
-                metrics.insert("instructions".into(), n as f64);
+            Some(c) => {
+                metrics.insert("instructions".into(), c.min as f64);
+                if c.is_suspect() {
+                    eprintln!(
+                        "warning: instruction count varied {:.2}% across {} runs. \
+                         The metric is deterministic, so this means the command \
+                         itself does environment-dependent work (an update check, \
+                         a cache it populates on first run, DNS). Its counts are \
+                         not a usable gate until that is removed.",
+                        c.spread_pct(),
+                        c.runs
+                    );
+                }
             }
             None => eprintln!(
                 "note: valgrind not found — recording timing only. \
@@ -353,8 +364,12 @@ fn cmd_backfill(
                 continue;
             }
         };
-        if let Ok(Some(n)) = measure::instructions(&cmd) {
-            metrics.insert("instructions".into(), n as f64);
+        let mut suspect = None;
+        if let Ok(Some(c)) = measure::instructions(&cmd) {
+            metrics.insert("instructions".into(), c.min as f64);
+            if c.is_suspect() {
+                suspect = Some(c.spread_pct());
+            }
         }
 
         let ins = metrics
@@ -362,8 +377,12 @@ fn cmd_backfill(
             .map(|v| format!("{v:>14.0}"))
             .unwrap_or_else(|| format!("{:>14}", "-"));
         println!(
-            "  {:<14} wall_min {:>8.2}ms   instructions {ins}",
-            rel.tag, metrics["wall_min_ms"]
+            "  {:<14} wall_min {:>8.2}ms   instructions {ins}{}",
+            rel.tag,
+            metrics["wall_min_ms"],
+            suspect
+                .map(|p| format!("   ⚠ varied {p:.1}%"))
+                .unwrap_or_default()
         );
 
         if dry_run {

--- a/src/main.rs
+++ b/src/main.rs
@@ -275,6 +275,15 @@ fn cmd_doctor() -> Result<()> {
     Ok(())
 }
 
+/// Removes the backfill work directory on every exit path, including `?`.
+struct TempDirGuard(std::path::PathBuf);
+
+impl Drop for TempDirGuard {
+    fn drop(&mut self) {
+        std::fs::remove_dir_all(&self.0).ok();
+    }
+}
+
 /// Infer "owner/name" from the `origin` remote.
 fn repo_from_origin() -> Option<String> {
     let out = std::process::Command::new("git")
@@ -285,10 +294,18 @@ fn repo_from_origin() -> Option<String> {
         return None;
     }
     let url = String::from_utf8_lossy(&out.stdout).trim().to_string();
-    // Handles https://github.com/o/r(.git) and git@github.com:o/r(.git).
-    let tail = url.rsplit_once("github.com").map(|(_, t)| t)?;
-    let slug = tail.trim_start_matches([':', '/']).trim_end_matches(".git");
-    (slug.matches('/').count() == 1).then(|| slug.to_string())
+    // Match the host exactly. Splitting on the substring "github.com" would
+    // accept `git@mygithub.com:o/r` and then query the wrong repository.
+    let rest = [
+        "https://github.com/",
+        "http://github.com/",
+        "git@github.com:",
+        "ssh://git@github.com/",
+    ]
+    .iter()
+    .find_map(|p| url.strip_prefix(p))?;
+    let slug = rest.trim_end_matches('/').trim_end_matches(".git");
+    (slug.matches('/').count() == 1 && !slug.is_empty()).then(|| slug.to_string())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -328,6 +345,9 @@ fn cmd_backfill(
     println!("{} release(s) from {repo}\n", releases.len());
 
     let workdir = std::env::temp_dir().join(format!("tak-backfill-{}", std::process::id()));
+    // Downloads can be hundreds of megabytes; a `?` partway through the loop
+    // must not leave them behind.
+    let _cleanup = TempDirGuard(workdir.clone());
     let mut recorded = 0usize;
     let mut skipped = 0usize;
 
@@ -338,7 +358,7 @@ fn cmd_backfill(
             continue;
         };
 
-        let dir = workdir.join(&rel.tag);
+        let dir = workdir.join(backfill::safe_dir_name(&rel.tag));
         let path = match backfill::fetch_binary(asset, &bin, &dir) {
             Ok(p) => p,
             Err(e) => {
@@ -413,8 +433,6 @@ fn cmd_backfill(
         notes::append(&sha, &[rec])?;
         recorded += 1;
     }
-
-    std::fs::remove_dir_all(&workdir).ok();
 
     if dry_run {
         println!("\n  dry run — nothing written");

--- a/src/measure.rs
+++ b/src/measure.rs
@@ -13,7 +13,7 @@
 //! clock (~1%) but not deterministic, because they move with thread scheduling.
 //! They are recorded, and may be flagged, but must not gate at a tight threshold.
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use std::collections::BTreeMap;
 use std::process::{Command, Stdio};
 use std::time::Instant;
@@ -72,6 +72,21 @@ pub fn wall(plan: &Plan) -> Result<BTreeMap<String, f64>> {
     ]))
 }
 
+/// Is cachegrind usable on this machine?
+///
+/// Exposed so callers can tell "no counters because valgrind is missing" from
+/// "no counters because the measurement failed" — two problems with entirely
+/// different fixes.
+pub fn valgrind_available() -> bool {
+    Command::new("valgrind")
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
 /// Repeats of the cachegrind run. Three is enough to catch a bimodal subject
 /// without tripling the cost of a measurement that is already ~50x slowed.
 const COUNTER_RUNS: u32 = 3;
@@ -122,13 +137,7 @@ impl Counted {
 /// Those platforms record timing only, and the CI gate lives on the Linux job.
 /// Locally, a container gets you counters on any host.
 pub fn instructions(cmd: &[String]) -> Result<Option<Counted>> {
-    if Command::new("valgrind")
-        .arg("--version")
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .is_err()
-    {
+    if !valgrind_available() {
         return Ok(None);
     }
 
@@ -150,9 +159,13 @@ pub fn instructions(cmd: &[String]) -> Result<Option<Counted>> {
         let stderr = String::from_utf8_lossy(&out.stderr);
         match parse_irefs(&stderr) {
             Some(n) => samples.push(n),
-            // Valgrind ran but produced no summary — treat as unavailable rather
-            // than reporting a count derived from fewer runs than promised.
-            None => return Ok(None),
+            // Valgrind is installed but produced no summary — a real failure,
+            // not the same thing as valgrind being absent. Reporting it as
+            // absent sends people off installing something they already have.
+            None => bail!(
+                "valgrind ran but emitted no `I refs` summary: {}",
+                stderr.lines().last().unwrap_or("(no output)").trim()
+            ),
         }
     }
 

--- a/src/measure.rs
+++ b/src/measure.rs
@@ -72,13 +72,56 @@ pub fn wall(plan: &Plan) -> Result<BTreeMap<String, f64>> {
     ]))
 }
 
-/// Instruction count via `valgrind --tool=cachegrind`.
+/// Repeats of the cachegrind run. Three is enough to catch a bimodal subject
+/// without tripling the cost of a measurement that is already ~50x slowed.
+const COUNTER_RUNS: u32 = 3;
+
+/// A subject varying by more than this is doing environment-dependent work, and
+/// its instruction count is not a usable gate. Well above the ~0.005% observed
+/// for a genuinely hermetic command, far below the 16% seen from one that
+/// touches the network.
+const SPREAD_WARN_PCT: f64 = 0.5;
+
+/// Instruction counts from repeated cachegrind runs.
+#[derive(Debug, Clone, Copy)]
+pub struct Counted {
+    pub min: u64,
+    pub max: u64,
+    pub runs: u32,
+}
+
+impl Counted {
+    /// Relative spread across runs, as a percentage of the minimum.
+    pub fn spread_pct(&self) -> f64 {
+        if self.min == 0 {
+            return 0.0;
+        }
+        (self.max - self.min) as f64 / self.min as f64 * 100.0
+    }
+
+    /// Whether this subject looks non-hermetic.
+    ///
+    /// The metric is deterministic; the program being measured need not be. A
+    /// CLI that checks for updates, reads a cache it may have just created, or
+    /// resolves DNS retires a different number of instructions depending on
+    /// conditions that have nothing to do with the code under test.
+    pub fn is_suspect(&self) -> bool {
+        self.spread_pct() > SPREAD_WARN_PCT
+    }
+}
+
+/// Instruction count via `valgrind --tool=cachegrind`, repeated.
+///
+/// Reports the **minimum**, for the same reason wall clock does: the extra work
+/// a subject sometimes performs is one-sided. A run that consults the network or
+/// populates a cache can only retire *more* instructions than the quiet path,
+/// never fewer, so the floor is the stable estimator.
 ///
 /// Returns `Ok(None)` when valgrind is unavailable rather than failing: this is
 /// the expected state on macOS (no usable Apple Silicon support) and Windows.
 /// Those platforms record timing only, and the CI gate lives on the Linux job.
 /// Locally, a container gets you counters on any host.
-pub fn instructions(cmd: &[String]) -> Result<Option<u64>> {
+pub fn instructions(cmd: &[String]) -> Result<Option<Counted>> {
     if Command::new("valgrind")
         .arg("--version")
         .stdout(Stdio::null())
@@ -89,21 +132,35 @@ pub fn instructions(cmd: &[String]) -> Result<Option<u64>> {
         return Ok(None);
     }
 
-    let out = Command::new("valgrind")
-        .args([
-            "--tool=cachegrind",
-            "--cache-sim=no",
-            "--branch-sim=no",
-            "--cachegrind-out-file=/dev/null",
-        ])
-        .args(cmd)
-        .stdout(Stdio::null())
-        .output()
-        .context("failed to run valgrind")?;
+    let mut samples: Vec<u64> = Vec::with_capacity(COUNTER_RUNS as usize);
+    for _ in 0..COUNTER_RUNS {
+        let out = Command::new("valgrind")
+            .args([
+                "--tool=cachegrind",
+                "--cache-sim=no",
+                "--branch-sim=no",
+                "--cachegrind-out-file=/dev/null",
+            ])
+            .args(cmd)
+            .stdout(Stdio::null())
+            .output()
+            .context("failed to run valgrind")?;
 
-    // cachegrind writes its summary to stderr as e.g. "I refs:  48,349,132".
-    let stderr = String::from_utf8_lossy(&out.stderr);
-    Ok(parse_irefs(&stderr))
+        // cachegrind writes its summary to stderr as e.g. "I refs:  48,349,132".
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        match parse_irefs(&stderr) {
+            Some(n) => samples.push(n),
+            // Valgrind ran but produced no summary — treat as unavailable rather
+            // than reporting a count derived from fewer runs than promised.
+            None => return Ok(None),
+        }
+    }
+
+    Ok(Some(Counted {
+        min: *samples.iter().min().expect("COUNTER_RUNS > 0"),
+        max: *samples.iter().max().expect("COUNTER_RUNS > 0"),
+        runs: COUNTER_RUNS,
+    }))
 }
 
 /// Extract the `I refs:` count from cachegrind's stderr summary.

--- a/src/notes.rs
+++ b/src/notes.rs
@@ -41,6 +41,33 @@ fn git(args: &[&str]) -> Result<String> {
     Ok(String::from_utf8_lossy(&out.stdout).trim_end().to_string())
 }
 
+/// Fallback identity arguments for commands that create a commit.
+///
+/// `git notes add` and `git notes merge` write commits, so git demands an
+/// author. Containers and fresh CI images routinely have none configured, and
+/// aborting a whole backfill for want of a name nobody will ever read is not a
+/// useful failure. Only applied when the user has not set one, so a real
+/// identity is never overridden.
+fn identity_args() -> Vec<&'static str> {
+    let configured = Command::new("git")
+        .args(["config", "--get", "user.email"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    if configured {
+        vec![]
+    } else {
+        vec!["-c", "user.name=tak", "-c", "user.email=tak@localhost"]
+    }
+}
+
+/// Like [`git`] but prepends a fallback identity, for commands that commit.
+fn git_committing(args: &[&str]) -> Result<String> {
+    let mut full = identity_args();
+    full.extend_from_slice(args);
+    git(&full)
+}
+
 /// Like [`git`] but returns the failure instead of raising, for calls whose
 /// failure is an expected outcome (a rejected push, a missing note).
 fn git_ok(args: &[&str]) -> Result<(bool, String)> {
@@ -101,7 +128,7 @@ pub fn append(commit: &str, records: &[Record]) -> Result<()> {
     lines.sort();
     lines.dedup();
 
-    git(&[
+    git_committing(&[
         "notes",
         "--ref",
         NOTES_REF,
@@ -135,7 +162,7 @@ pub fn push(remote: &str) -> Result<()> {
             remote,
             "+refs/notes/tak:refs/notes/tak-remote",
         ])?;
-        git(&[
+        git_committing(&[
             "notes",
             "--ref",
             NOTES_REF,

--- a/src/notes.rs
+++ b/src/notes.rs
@@ -49,16 +49,23 @@ fn git(args: &[&str]) -> Result<String> {
 /// useful failure. Only applied when the user has not set one, so a real
 /// identity is never overridden.
 fn identity_args() -> Vec<&'static str> {
-    let configured = Command::new("git")
-        .args(["config", "--get", "user.email"])
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false);
-    if configured {
-        vec![]
-    } else {
-        vec!["-c", "user.name=tak", "-c", "user.email=tak@localhost"]
+    let configured = |key: &str| {
+        Command::new("git")
+            .args(["config", "--get", key])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    };
+    // Checked independently: a machine with `user.name` set but no email would
+    // otherwise have its real name replaced by the placeholder.
+    let mut args = Vec::new();
+    if !configured("user.name") {
+        args.extend_from_slice(&["-c", "user.name=tak"]);
     }
+    if !configured("user.email") {
+        args.extend_from_slice(&["-c", "user.email=tak@localhost"]);
+    }
+    args
 }
 
 /// Like [`git`] but prepends a fallback identity, for commands that commit.

--- a/tests/counters.rs
+++ b/tests/counters.rs
@@ -9,19 +9,9 @@
 //! Every test skips cleanly when valgrind is unavailable, because that is the
 //! normal state on macOS and Windows.
 
-use std::process::{Command, Stdio};
-
 use tak_cli::measure::{self, Plan};
 
-fn valgrind_available() -> bool {
-    Command::new("valgrind")
-        .arg("--version")
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
-}
+use tak_cli::measure::valgrind_available;
 
 /// A command that exists on the host and does a trivial, fixed amount of work.
 ///
@@ -96,6 +86,24 @@ fn instruction_counts_are_deterministic() {
     );
     // /bin/echo is hermetic, so nothing here should look suspect.
     assert!(outer.iter().all(|c| !c.is_suspect()));
+}
+
+/// The two "no counters" outcomes must stay distinguishable: a missing valgrind
+/// is `Ok(None)`, while valgrind failing mid-measurement is an error. Reporting
+/// the latter as the former sends people installing what they already have.
+#[test]
+fn availability_and_failure_are_distinct() {
+    if valgrind_available() {
+        // A command that cannot be spawned makes cachegrind fail rather than
+        // vanish, so this must be an error rather than Ok(None).
+        let bogus = vec!["/nonexistent/tak-not-a-real-binary".to_string()];
+        assert!(
+            measure::instructions(&bogus).is_err(),
+            "a failed measurement must not look like a missing valgrind"
+        );
+    } else {
+        assert!(measure::instructions(&subject()).unwrap().is_none());
+    }
 }
 
 /// Absence of valgrind must degrade to timing-only, never fail the run.

--- a/tests/counters.rs
+++ b/tests/counters.rs
@@ -45,13 +45,22 @@ fn instructions_are_reported_when_valgrind_exists() {
         eprintln!("skipping: valgrind not installed");
         return;
     }
-    let n = measure::instructions(&subject())
+    let c = measure::instructions(&subject())
         .expect("cachegrind invocation failed")
         .expect("valgrind present but no I refs parsed");
 
     // A dynamically linked process cannot retire a trivially small number of
     // instructions; anything tiny means we parsed the wrong thing.
-    assert!(n > 10_000, "implausibly low instruction count: {n}");
+    assert!(
+        c.min > 10_000,
+        "implausibly low instruction count: {}",
+        c.min
+    );
+    assert!(c.max >= c.min);
+    assert!(
+        c.runs >= 2,
+        "a single sample cannot detect a varying subject"
+    );
 }
 
 /// The claim the CI gate depends on: repeated runs of an identical command
@@ -66,7 +75,9 @@ fn instruction_counts_are_deterministic() {
         return;
     }
     let cmd = subject();
-    let runs: Vec<u64> = (0..3)
+    // `instructions` already samples repeatedly; doing it again covers variation
+    // across separate invocations too, not just within one.
+    let outer: Vec<_> = (0..2)
         .map(|_| {
             measure::instructions(&cmd)
                 .expect("cachegrind invocation failed")
@@ -74,15 +85,17 @@ fn instruction_counts_are_deterministic() {
         })
         .collect();
 
-    let min = *runs.iter().min().unwrap();
-    let max = *runs.iter().max().unwrap();
+    let min = outer.iter().map(|c| c.min).min().unwrap();
+    let max = outer.iter().map(|c| c.max).max().unwrap();
     let spread = (max - min) as f64 / min as f64 * 100.0;
 
     assert!(
         spread < 0.1,
-        "instruction counts varied by {spread:.4}% across {runs:?} — \
-         the deterministic-gate premise does not hold on this platform"
+        "instruction counts varied by {spread:.4}% — the deterministic-gate \
+         premise does not hold on this platform"
     );
+    // /bin/echo is hermetic, so nothing here should look suspect.
+    assert!(outer.iter().all(|c| !c.is_suspect()));
 }
 
 /// Absence of valgrind must degrade to timing-only, never fail the run.


### PR DESCRIPTION
> **Stacked on #2.** Base is `verify-counters`; retarget to `main` once that merges.

## Why

A new adopter's first chart is empty, and an empty chart persuades nobody. Rebuilding a project at a hundred historical commits costs hours of compute and is impossible for anyone whose old commits no longer build. Downloading the binaries the project **already published** takes seconds and always works.

This is the one idea worth stealing from [Chronologer](https://github.com/dandavison/chronologer), which has been sitting unused.

## Worked example

Six releases of `sharkdp/hyperfine`, measured in seconds:

| release | instructions | |
|---|---:|---|
| v1.16.0 | 128,819 | |
| v1.16.1 | 128,819 | identical — a patch that didn't touch startup |
| v1.17.0 | 115,144 | −10.6% |
| v1.18.0 | 135,851 | +18.0% |
| v1.19.0 | 154,219 | +13.5% |
| v1.20.0 | 161,829 | +4.9% |

hyperfine's own `--version` startup grew **~40% between v1.17.0 and v1.20.0**. The two v1.16 releases coming back byte-identical is a useful sanity check on the whole approach.

Wall clock over the same set moved 0.23ms → 0.33ms — the same shape, far noisier.

## Design notes

**Asset selection is deliberately conservative.** A wrong pick produces numbers that look real and mean nothing, which is worse than backfilling nothing. Checksums, signatures, SBOMs, `.deb`/`.rpm`/`.msi`/`.pkg` are rejected outright; the OS must match; musl and tarballs score higher because they extract cleanly in slim images. If nothing matches, the release is skipped with a reason rather than guessed at.

**Records attach to the tagged commit** and carry the release's own `published_at` rather than now, so the series lands on the real timeline instead of bunching at the moment you ran the backfill. A shallow clone with no tags is a skip, not an error.

**No new dependencies.** Network and archives shell out to `curl` and `tar`/`unzip`, the same reasoning as `notes.rs` shelling out to `git` — proxies, CA bundles and credential helpers are already solved there.

**`--dry-run`** measures without writing, which is how the table above was produced.

## Tests

23 total. New pure-function coverage for asset scoring: rejects checksums and signatures, rejects other platforms, rejects distro packages, prefers musl over gnu, prefers tarball over zip, accepts `x86_64`/`amd64`/`x64` spellings, picks the best candidate from a realistic asset list, strips only the `v` prefix from tags (non-semver tags like `nightly` and `lts-iron` must survive untouched), and finds a nested binary.

`cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New network/download path executes third-party release binaries and writes git notes; curl/token and HTTPS redirect handling are security-sensitive but deliberately hardened. Instruction-count API change affects all counter consumers.
> 
> **Overview**
> Adds **`tak backfill`** to bootstrap performance history by downloading published GitHub release assets, benchmarking them (default `--version`), and appending results to `refs/notes/tak` on each release’s tagged commit (using `published_at` when available). Supports `--repo`, `--bin`, `--dry-run`, and infers `owner/name` from `origin` when omitted.
> 
> Introduces **`src/backfill`**: paginated releases API via `curl` (HTTPS-only, token via stdin config), conservative platform asset scoring, fetch/unpack (`tar`/`unzip`), and safe path handling. Skips prereleases, drafts, missing platform assets, and tags not present locally.
> 
> **Measurement layer:** `instructions()` now runs cachegrind **three times**, returns a **`Counted`** struct (min used for storage), warns on high spread (`is_suspect`), and distinguishes missing valgrind (`Ok(None)`) from measurement failure (`Err`). **`tak run`** surfaces those warnings/errors.
> 
> **Git notes:** `notes::append` / merge use a fallback `user.name` / `user.email` when unset so backfill works in CI/containers.
> 
> README marks backfill as shipped; counter integration tests updated for the new API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 486f313554fa72493963b9b2f1877c898196d0dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->