### PR TITLE
ci: add zizmor

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,25 @@
+name: zizmor
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths: [".github/workflows/**"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@6fc4b006235f201fdab3722e17240ab420d580e5 # v0.6.1
+        with:
+          advanced-security: false

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -2,6 +2,10 @@ name: zizmor
 on:
   push:
     branches: [main]
+    # Filtered on push as well as pull_request. zizmor only audits workflow
+    # files, so running it for an unrelated push burns a runner and reports on
+    # content that has not changed.
+    paths: [".github/workflows/**"]
   pull_request:
     paths: [".github/workflows/**"]
 


### PR DESCRIPTION
Static analysis for the workflows themselves — template injection, credential persistence, cache poisoning, impostor commits. Matches the standalone `zizmor.yml` in aube, fnox and mise-action.

- Runs only on `.github/workflows/**` changes, since that is the only thing it audits.
- `permissions: {}` at the top level with `contents: read` on the job keeps the token minimal.
- `advanced-security: false` reports findings in the job log rather than requiring GitHub Advanced Security.
- Action pinned to a full commit SHA, consistent with the other workflows here.

I ran `zizmor 1.27.0` locally against every workflow in this repo before opening this — **no findings**, so it should go green immediately rather than landing a red check.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds read-only CI only; no application, auth, or data-path changes.
> 
> **Overview**
> Adds a **zizmor** GitHub Actions workflow that statically audits workflow YAML for issues such as template injection, credential persistence, cache poisoning, and impostor commits.
> 
> The job runs only when `.github/workflows/**` changes on `push` to `main` and on `pull_request`, with concurrency cancellation to avoid duplicate runs. It uses minimal permissions (`permissions: {}` at workflow scope, `contents: read` on the job), pins `actions/checkout` and `zizmor-action` to full SHAs, disables checkout credential persistence, and sets `advanced-security: false` so findings appear in the job log without GitHub Advanced Security.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5c47e34c0d71b9a98bf46cd17c4ae7a3891ac5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->