### PR TITLE
feat: declare benchmarks in tak.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+.claude/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,10 +121,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -241,6 +263,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,7 +297,47 @@ dependencies = [
  "clap",
  "serde",
  "serde_json",
+ "toml",
 ]
+
+[[package]]
+name = "toml"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "unicode-ident"
@@ -294,6 +365,12 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ asset-picker = { path = "crates/asset-picker", version = "0.0.1" }
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+toml = "1.1.3"
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -97,13 +97,33 @@ Measuring and storing work. Nothing reads the data back yet.
 - [x] concurrent CI writers merge via `cat_sort_uniq`
 - [x] `tak backfill` — benchmark published release binaries to bootstrap history
 - [x] asset selection via `crates/asset-picker`, extracted from mise
+- [x] `tak.toml` — declare benchmarks so CI and a laptop measure the same thing
 - [ ] `tak compare <ref>` — interleaved A/B against another revision
-- [ ] `bench.toml`
+
 - [ ] PR reporting
 - [ ] change-point detection instead of thresholds
 
 Releases are automated with release-plz and publish to crates.io via trusted publishing —
 see [RELEASING.md](RELEASING.md). The crate is `tak-cli`; the binary is `tak`.
+
+## Declaring benchmarks
+
+`tak run` with no command runs whatever `tak.toml` declares, searching upward from the working
+directory. The point is that CI and a laptop measure the same thing — a command line in a
+workflow file drifts from the one people run locally, and the numbers stop being comparable
+without anyone noticing.
+
+```toml
+[bench.startup]
+cmd = ["./target/release/mycli", "--version"]
+
+[bench.help]
+cmd = "mycli --help"    # split on whitespace; there is no shell
+runs = 10
+```
+
+`tak run --bench startup` runs one of them. A command after `--` always wins, so ad-hoc
+measurement never depends on repository state.
 
 ## Counters on macOS and Windows
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,182 @@
+//! `tak.toml` — declared benchmarks.
+//!
+//! Named after the tool rather than after its current contents. It already
+//! holds more than a command list in spirit, and gates, runner classes and
+//! competitor definitions all belong here too; `bench.toml` would be misnamed
+//! the moment the first of those lands.
+//!
+//! The point of declaring benchmarks is that CI and a laptop run the same
+//! thing. A command line in a workflow file drifts from the one people use
+//! locally, and the numbers stop being comparable without anyone noticing.
+
+use anyhow::{Context, Result, bail};
+use serde::Deserialize;
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+pub const FILE_NAME: &str = "tak.toml";
+
+/// Defaults chosen to match `tak run`'s, so moving a command into `tak.toml`
+/// does not silently change what it measures.
+const DEFAULT_RUNS: u32 = 20;
+const DEFAULT_WARMUP: u32 = 3;
+
+#[derive(Debug, Deserialize)]
+pub struct Config {
+    /// Benchmarks by name. A BTreeMap so runs are ordered and reproducible
+    /// rather than following the file's incidental key order.
+    #[serde(default)]
+    pub bench: BTreeMap<String, Bench>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Bench {
+    cmd: Cmd,
+    pub runs: Option<u32>,
+    pub warmup: Option<u32>,
+}
+
+/// A command, written either as a list or as a plain string.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum Cmd {
+    Argv(Vec<String>),
+    Line(String),
+}
+
+impl Bench {
+    /// The command as argv.
+    ///
+    /// A string is split on whitespace and nothing else. There is deliberately
+    /// no shell: spawning one adds its own startup cost and variance to every
+    /// sample, which for commands in the 10ms range is a large fraction of the
+    /// measurement. Anything needing a pipe or a glob should be a list whose
+    /// first element is the interpreter.
+    pub fn argv(&self) -> Result<Vec<String>> {
+        let v = match &self.cmd {
+            Cmd::Argv(v) => v.clone(),
+            Cmd::Line(s) => s.split_whitespace().map(str::to_string).collect(),
+        };
+        if v.is_empty() {
+            bail!("empty command");
+        }
+        Ok(v)
+    }
+
+    pub fn runs(&self) -> u32 {
+        self.runs.unwrap_or(DEFAULT_RUNS)
+    }
+
+    pub fn warmup(&self) -> u32 {
+        self.warmup.unwrap_or(DEFAULT_WARMUP)
+    }
+}
+
+impl Config {
+    pub fn parse(text: &str) -> Result<Self> {
+        let cfg: Config = toml::from_str(text).context("could not parse tak.toml")?;
+        // Every declared benchmark is validated up front rather than failing
+        // partway through a run that has already spent minutes measuring.
+        for (name, b) in &cfg.bench {
+            b.argv()
+                .with_context(|| format!("benchmark `{name}` has no command"))?;
+        }
+        Ok(cfg)
+    }
+
+    /// Find and load `tak.toml`, searching upward from `start`.
+    ///
+    /// Walking up means `tak run` behaves the same from a subdirectory as from
+    /// the repository root, which is where people actually are.
+    pub fn find(start: &Path) -> Result<Option<(PathBuf, Self)>> {
+        for dir in start.ancestors() {
+            let path = dir.join(FILE_NAME);
+            if path.is_file() {
+                let text = std::fs::read_to_string(&path)
+                    .with_context(|| format!("could not read {}", path.display()))?;
+                let cfg = Self::parse(&text).with_context(|| format!("in {}", path.display()))?;
+                return Ok(Some((path, cfg)));
+            }
+        }
+        Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_command_may_be_a_list_or_a_string() {
+        let c = Config::parse(
+            r#"
+            [bench.a]
+            cmd = ["mycli", "--version"]
+            [bench.b]
+            cmd = "mycli --help"
+            "#,
+        )
+        .unwrap();
+        assert_eq!(c.bench["a"].argv().unwrap(), ["mycli", "--version"]);
+        assert_eq!(c.bench["b"].argv().unwrap(), ["mycli", "--help"]);
+    }
+
+    /// A string is split on whitespace and nothing else — no shell means no
+    /// quoting, and pretending otherwise would measure the wrong thing.
+    #[test]
+    fn a_string_command_gets_no_shell_semantics() {
+        let c = Config::parse(
+            r#"[bench.a]
+cmd = "mycli 'two words'""#,
+        )
+        .unwrap();
+        assert_eq!(c.bench["a"].argv().unwrap(), ["mycli", "'two", "words'"]);
+    }
+
+    #[test]
+    fn defaults_match_the_cli() {
+        let c = Config::parse("[bench.a]\ncmd = \"x\"").unwrap();
+        assert_eq!(c.bench["a"].runs(), DEFAULT_RUNS);
+        assert_eq!(c.bench["a"].warmup(), DEFAULT_WARMUP);
+    }
+
+    #[test]
+    fn per_benchmark_overrides_win() {
+        let c = Config::parse("[bench.a]\ncmd = \"x\"\nruns = 5\nwarmup = 1").unwrap();
+        assert_eq!(c.bench["a"].runs(), 5);
+        assert_eq!(c.bench["a"].warmup(), 1);
+    }
+
+    /// Validation happens at load, not partway through a run that has already
+    /// spent minutes measuring.
+    #[test]
+    fn an_empty_command_is_rejected_at_parse_time() {
+        let err = Config::parse("[bench.a]\ncmd = []").unwrap_err();
+        assert!(format!("{err:#}").contains('a'), "{err:#}");
+    }
+
+    #[test]
+    fn benchmarks_run_in_a_stable_order() {
+        let c = Config::parse("[bench.zebra]\ncmd = \"z\"\n[bench.alpha]\ncmd = \"a\"").unwrap();
+        assert_eq!(c.bench.keys().collect::<Vec<_>>(), ["alpha", "zebra"]);
+    }
+
+    #[test]
+    fn an_empty_file_declares_nothing() {
+        assert!(Config::parse("").unwrap().bench.is_empty());
+    }
+
+    #[test]
+    fn find_walks_up_from_a_subdirectory() {
+        let root = std::env::temp_dir().join(format!("tak-cfg-{}", std::process::id()));
+        let nested = root.join("a").join("b");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(root.join(FILE_NAME), "[bench.x]\ncmd = \"true\"").unwrap();
+
+        let (path, cfg) = Config::find(&nested).unwrap().expect("should find it");
+        assert_eq!(path, root.join(FILE_NAME));
+        assert!(cfg.bench.contains_key("x"));
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,8 +18,8 @@ pub const FILE_NAME: &str = "tak.toml";
 
 /// Defaults chosen to match `tak run`'s, so moving a command into `tak.toml`
 /// does not silently change what it measures.
-const DEFAULT_RUNS: u32 = 20;
-const DEFAULT_WARMUP: u32 = 3;
+pub const DEFAULT_RUNS: u32 = 20;
+pub const DEFAULT_WARMUP: u32 = 3;
 
 #[derive(Debug, Deserialize)]
 pub struct Config {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 //! written-but-never-executed, which is exactly the failure this guards against.
 
 pub mod backfill;
+pub mod config;
 pub mod measure;
 pub mod notes;
 pub mod record;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use clap::{Parser, Subcommand};
 use std::collections::BTreeMap;
 
 use tak_cli::backfill;
+use tak_cli::config::{self, Config};
 use tak_cli::measure::{self, Plan};
 use tak_cli::notes;
 use tak_cli::record::{Record, SCHEMA_VERSION};
@@ -20,11 +21,12 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Cmd {
-    /// Benchmark a command.
+    /// Benchmark a command, or everything declared in tak.toml.
     Run {
-        /// Name to record this measurement under.
-        #[arg(long, default_value = "default")]
-        bench: String,
+        /// Name to record this measurement under. With no command, selects a
+        /// single benchmark from tak.toml instead of running all of them.
+        #[arg(long)]
+        bench: Option<String>,
         /// Timed runs.
         #[arg(long, default_value_t = 20)]
         runs: u32,
@@ -37,8 +39,8 @@ enum Cmd {
         /// Append the result to refs/notes/tak for the current commit.
         #[arg(long)]
         record: bool,
-        /// Command to benchmark, after `--`.
-        #[arg(last = true, required = true)]
+        /// Command to benchmark, after `--`. Omit to run what tak.toml declares.
+        #[arg(last = true)]
         cmd: Vec<String>,
     },
     /// Show recorded history for a commit.
@@ -137,23 +139,82 @@ fn now_rfc3339() -> String {
 }
 
 fn cmd_run(
-    bench: String,
+    bench: Option<String>,
     runs: u32,
     warmup: u32,
     no_counters: bool,
     record_it: bool,
     cmd: Vec<String>,
 ) -> Result<()> {
+    // An explicit command always wins; tak.toml is only consulted when none is
+    // given, so ad-hoc measurement never depends on repository state.
+    if cmd.is_empty() {
+        return run_declared(bench, no_counters, record_it);
+    }
+    let bench = bench.unwrap_or_else(|| "default".to_string());
     let plan = Plan {
         cmd: cmd.clone(),
         warmup,
         runs,
     };
+    measure_and_report(&bench, &plan, no_counters, record_it)
+}
 
-    let mut metrics: BTreeMap<String, f64> = measure::wall(&plan)?;
+/// Run the benchmarks declared in `tak.toml`.
+fn run_declared(only: Option<String>, no_counters: bool, record_it: bool) -> Result<()> {
+    let cwd = std::env::current_dir()?;
+    let Some((path, cfg)) = Config::find(&cwd)? else {
+        bail!(
+            "no command given and no {} found in {} or any parent.\n\
+             Pass a command after `--`, or declare one:\n\n\
+             \x20   [bench.startup]\n\
+             \x20   cmd = [\"./mycli\", \"--version\"]",
+            config::FILE_NAME,
+            cwd.display()
+        );
+    };
+
+    let selected: Vec<_> = match &only {
+        Some(name) => {
+            let b = cfg.bench.get(name).with_context(|| {
+                format!(
+                    "no benchmark `{name}` in {} (found: {})",
+                    path.display(),
+                    if cfg.bench.is_empty() {
+                        "none".to_string()
+                    } else {
+                        cfg.bench.keys().cloned().collect::<Vec<_>>().join(", ")
+                    }
+                )
+            })?;
+            vec![(name.clone(), b)]
+        }
+        None => cfg.bench.iter().map(|(k, v)| (k.clone(), v)).collect(),
+    };
+
+    if selected.is_empty() {
+        println!("{} declares no benchmarks", path.display());
+        return Ok(());
+    }
+
+    for (name, b) in selected {
+        let plan = Plan {
+            cmd: b.argv()?,
+            warmup: b.warmup(),
+            runs: b.runs(),
+        };
+        measure_and_report(&name, &plan, no_counters, record_it)?;
+    }
+    Ok(())
+}
+
+/// Measure one benchmark, print it, and optionally record it.
+fn measure_and_report(bench: &str, plan: &Plan, no_counters: bool, record_it: bool) -> Result<()> {
+    let cmd = &plan.cmd;
+    let mut metrics: BTreeMap<String, f64> = measure::wall(plan)?;
 
     if !no_counters {
-        match measure::instructions(&cmd) {
+        match measure::instructions(cmd) {
             Ok(Some(c)) => {
                 metrics.insert("instructions".into(), c.min as f64);
                 if c.is_suspect() {
@@ -179,7 +240,7 @@ fn cmd_run(
         }
     }
 
-    println!("  {}", cmd.join(" "));
+    println!("  {bench}  {}", cmd.join(" "));
     for (k, v) in &metrics {
         if k == "wall_n" {
             continue;
@@ -195,7 +256,7 @@ fn cmd_run(
         let sha = notes::rev_parse("HEAD").context("not in a git repository")?;
         let rec = Record {
             v: SCHEMA_VERSION,
-            bench,
+            bench: bench.to_string(),
             tool: std::env::var("TAK_TOOL").unwrap_or_else(|_| "self".into()),
             version: None,
             runner: runner_class(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,9 +5,10 @@
 use anyhow::{Context, Result, bail};
 use clap::{Parser, Subcommand};
 use std::collections::BTreeMap;
+use std::path::Path;
 
 use tak_cli::backfill;
-use tak_cli::config::{self, Config};
+use tak_cli::config::{self, Config, DEFAULT_RUNS, DEFAULT_WARMUP};
 use tak_cli::measure::{self, Plan};
 use tak_cli::notes;
 use tak_cli::record::{Record, SCHEMA_VERSION};
@@ -27,12 +28,12 @@ enum Cmd {
         /// single benchmark from tak.toml instead of running all of them.
         #[arg(long)]
         bench: Option<String>,
-        /// Timed runs.
-        #[arg(long, default_value_t = 20)]
-        runs: u32,
-        /// Untimed warmup runs.
-        #[arg(long, default_value_t = 3)]
-        warmup: u32,
+        /// Timed runs. Overrides tak.toml when both are given.
+        #[arg(long)]
+        runs: Option<u32>,
+        /// Untimed warmup runs. Overrides tak.toml when both are given.
+        #[arg(long)]
+        warmup: Option<u32>,
         /// Skip instruction counting even where valgrind is available.
         #[arg(long)]
         no_counters: bool,
@@ -140,8 +141,8 @@ fn now_rfc3339() -> String {
 
 fn cmd_run(
     bench: Option<String>,
-    runs: u32,
-    warmup: u32,
+    runs: Option<u32>,
+    warmup: Option<u32>,
     no_counters: bool,
     record_it: bool,
     cmd: Vec<String>,
@@ -149,19 +150,30 @@ fn cmd_run(
     // An explicit command always wins; tak.toml is only consulted when none is
     // given, so ad-hoc measurement never depends on repository state.
     if cmd.is_empty() {
-        return run_declared(bench, no_counters, record_it);
+        return run_declared(bench, runs, warmup, no_counters, record_it);
     }
     let bench = bench.unwrap_or_else(|| "default".to_string());
     let plan = Plan {
         cmd: cmd.clone(),
-        warmup,
-        runs,
+        warmup: warmup.unwrap_or(DEFAULT_WARMUP),
+        runs: runs.unwrap_or(DEFAULT_RUNS),
+        dir: None,
     };
-    measure_and_report(&bench, &plan, no_counters, record_it)
+    let rec = measure_and_report(&bench, &plan, no_counters)?;
+    if record_it {
+        record_all(&[rec])?;
+    }
+    Ok(())
 }
 
 /// Run the benchmarks declared in `tak.toml`.
-fn run_declared(only: Option<String>, no_counters: bool, record_it: bool) -> Result<()> {
+fn run_declared(
+    only: Option<String>,
+    runs: Option<u32>,
+    warmup: Option<u32>,
+    no_counters: bool,
+    record_it: bool,
+) -> Result<()> {
     let cwd = std::env::current_dir()?;
     let Some((path, cfg)) = Config::find(&cwd)? else {
         bail!(
@@ -197,24 +209,55 @@ fn run_declared(only: Option<String>, no_counters: bool, record_it: bool) -> Res
         return Ok(());
     }
 
+    // Commands are relative to tak.toml, not to wherever this was invoked.
+    let root = path.parent().map(Path::to_path_buf);
+
+    // Everything is measured before anything is written. Recording as each
+    // benchmark finishes would leave a partial set behind when a later one
+    // fails to spawn — an incomplete run that looks like a complete one.
+    let mut records = Vec::new();
     for (name, b) in selected {
         let plan = Plan {
             cmd: b.argv()?,
-            warmup: b.warmup(),
-            runs: b.runs(),
+            // An explicit flag beats the file; the file beats the default.
+            warmup: warmup.unwrap_or_else(|| b.warmup()),
+            runs: runs.unwrap_or_else(|| b.runs()),
+            dir: root.clone(),
         };
-        measure_and_report(&name, &plan, no_counters, record_it)?;
+        records.push(measure_and_report(&name, &plan, no_counters)?);
+    }
+    if record_it {
+        record_all(&records)?;
     }
     Ok(())
 }
 
+/// Append every record in one write, so a run is stored whole or not at all.
+fn record_all(records: &[Record]) -> Result<()> {
+    if records.is_empty() {
+        return Ok(());
+    }
+    let sha = notes::rev_parse("HEAD").context("not in a git repository")?;
+    notes::append(&sha, records)?;
+    println!(
+        "\n  recorded {} measurement(s) to {} for {}",
+        records.len(),
+        notes::NOTES_REF,
+        &sha[..12]
+    );
+    println!("  push with: tak push");
+    Ok(())
+}
+
 /// Measure one benchmark, print it, and optionally record it.
-fn measure_and_report(bench: &str, plan: &Plan, no_counters: bool, record_it: bool) -> Result<()> {
+/// Measure one benchmark and print it. Returns the record; writing is the
+/// caller's job, so a multi-benchmark run can be stored atomically.
+fn measure_and_report(bench: &str, plan: &Plan, no_counters: bool) -> Result<Record> {
     let cmd = &plan.cmd;
     let mut metrics: BTreeMap<String, f64> = measure::wall(plan)?;
 
     if !no_counters {
-        match measure::instructions(cmd) {
+        match measure::instructions(cmd, plan.dir.as_deref()) {
             Ok(Some(c)) => {
                 metrics.insert("instructions".into(), c.min as f64);
                 if c.is_suspect() {
@@ -252,23 +295,15 @@ fn measure_and_report(bench: &str, plan: &Plan, no_counters: bool, record_it: bo
         }
     }
 
-    if record_it {
-        let sha = notes::rev_parse("HEAD").context("not in a git repository")?;
-        let rec = Record {
-            v: SCHEMA_VERSION,
-            bench: bench.to_string(),
-            tool: std::env::var("TAK_TOOL").unwrap_or_else(|_| "self".into()),
-            version: None,
-            runner: runner_class(),
-            ts: now_rfc3339(),
-            metrics,
-        };
-        notes::append(&sha, &[rec])?;
-        println!("\n  recorded to {} for {}", notes::NOTES_REF, &sha[..12]);
-        println!("  push with: tak push");
-    }
-
-    Ok(())
+    Ok(Record {
+        v: SCHEMA_VERSION,
+        bench: bench.to_string(),
+        tool: std::env::var("TAK_TOOL").unwrap_or_else(|_| "self".into()),
+        version: None,
+        runner: runner_class(),
+        ts: now_rfc3339(),
+        metrics,
+    })
 }
 
 fn cmd_history(rev: String, remote: String) -> Result<()> {
@@ -439,6 +474,8 @@ fn cmd_backfill(
             cmd: cmd.clone(),
             warmup: 2,
             runs,
+            // Release binaries are extracted to absolute paths.
+            dir: None,
         };
         let mut metrics = match measure::wall(&plan) {
             Ok(m) => m,
@@ -449,7 +486,7 @@ fn cmd_backfill(
             }
         };
         let mut suspect = None;
-        if let Ok(Some(c)) = measure::instructions(&cmd) {
+        if let Ok(Some(c)) = measure::instructions(&cmd, None) {
             metrics.insert("instructions".into(), c.min as f64);
             if c.is_suspect() {
                 suspect = Some(c.spread_pct());

--- a/src/measure.rs
+++ b/src/measure.rs
@@ -23,6 +23,10 @@ pub struct Plan {
     pub cmd: Vec<String>,
     pub warmup: u32,
     pub runs: u32,
+    /// Directory to run in. Declared benchmarks resolve relative commands
+    /// against `tak.toml`'s directory, not the caller's — otherwise the same
+    /// benchmark measures different things depending on where you stood.
+    pub dir: Option<std::path::PathBuf>,
 }
 
 /// Run once, discarding output, returning elapsed wall time in milliseconds.
@@ -30,13 +34,15 @@ pub struct Plan {
 /// No shell. Spawning a shell adds its own startup cost and variance to every
 /// sample, which for commands in the 10ms range is a large fraction of the
 /// measurement — the same reasoning behind poop's refusal to support one.
-fn time_once(cmd: &[String]) -> Result<f64> {
+fn time_once(cmd: &[String], dir: Option<&std::path::Path>) -> Result<f64> {
     let (bin, args) = cmd.split_first().context("empty command")?;
+    let mut c = Command::new(bin);
+    c.args(args).stdout(Stdio::null()).stderr(Stdio::null());
+    if let Some(d) = dir {
+        c.current_dir(d);
+    }
     let start = Instant::now();
-    let status = Command::new(bin)
-        .args(args)
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
+    let status = c
         .status()
         .with_context(|| format!("failed to spawn `{bin}`"))?;
     let elapsed = start.elapsed().as_secs_f64() * 1000.0;
@@ -50,12 +56,17 @@ fn time_once(cmd: &[String]) -> Result<f64> {
 /// machine can only make a run slower, never faster — so the minimum is a far
 /// more robust estimator than the mean on shared CI hardware.
 pub fn wall(plan: &Plan) -> Result<BTreeMap<String, f64>> {
+    // Zero runs would leave `samples` empty and index straight off the end.
+    if plan.runs == 0 {
+        bail!("runs must be at least 1");
+    }
+    let dir = plan.dir.as_deref();
     for _ in 0..plan.warmup {
-        time_once(&plan.cmd)?;
+        time_once(&plan.cmd, dir)?;
     }
     let mut samples = Vec::with_capacity(plan.runs as usize);
     for _ in 0..plan.runs {
-        samples.push(time_once(&plan.cmd)?);
+        samples.push(time_once(&plan.cmd, dir)?);
     }
     samples.sort_by(|a, b| a.partial_cmp(b).unwrap());
 
@@ -136,24 +147,26 @@ impl Counted {
 /// the expected state on macOS (no usable Apple Silicon support) and Windows.
 /// Those platforms record timing only, and the CI gate lives on the Linux job.
 /// Locally, a container gets you counters on any host.
-pub fn instructions(cmd: &[String]) -> Result<Option<Counted>> {
+pub fn instructions(cmd: &[String], dir: Option<&std::path::Path>) -> Result<Option<Counted>> {
     if !valgrind_available() {
         return Ok(None);
     }
 
     let mut samples: Vec<u64> = Vec::with_capacity(COUNTER_RUNS as usize);
     for _ in 0..COUNTER_RUNS {
-        let out = Command::new("valgrind")
-            .args([
-                "--tool=cachegrind",
-                "--cache-sim=no",
-                "--branch-sim=no",
-                "--cachegrind-out-file=/dev/null",
-            ])
-            .args(cmd)
-            .stdout(Stdio::null())
-            .output()
-            .context("failed to run valgrind")?;
+        let mut c = Command::new("valgrind");
+        c.args([
+            "--tool=cachegrind",
+            "--cache-sim=no",
+            "--branch-sim=no",
+            "--cachegrind-out-file=/dev/null",
+        ])
+        .args(cmd)
+        .stdout(Stdio::null());
+        if let Some(d) = dir {
+            c.current_dir(d);
+        }
+        let out = c.output().context("failed to run valgrind")?;
 
         // cachegrind writes its summary to stderr as e.g. "I refs:  48,349,132".
         let stderr = String::from_utf8_lossy(&out.stderr);
@@ -204,11 +217,23 @@ mod tests {
     }
 
     #[test]
+    fn zero_runs_is_rejected_not_a_panic() {
+        let plan = Plan {
+            cmd: vec!["true".into()],
+            warmup: 0,
+            runs: 0,
+            dir: None,
+        };
+        assert!(wall(&plan).is_err());
+    }
+
+    #[test]
     fn wall_reports_min_le_p50_le_max() {
         let plan = Plan {
             cmd: vec!["true".into()],
             warmup: 1,
             runs: 5,
+            dir: None,
         };
         let m = wall(&plan).unwrap();
         assert!(m["wall_min_ms"] <= m["wall_p50_ms"]);

--- a/tak.toml
+++ b/tak.toml
@@ -1,0 +1,8 @@
+# Benchmarks for tak itself. Startup cost is what a CLI's users feel first, and
+# it is the metric instruction counting measures best.
+[bench.version]
+cmd = ["./target/release/tak", "--version"]
+
+[bench.help]
+cmd = ["./target/release/tak", "--help"]
+runs = 10

--- a/tests/counters.rs
+++ b/tests/counters.rs
@@ -35,7 +35,7 @@ fn instructions_are_reported_when_valgrind_exists() {
         eprintln!("skipping: valgrind not installed");
         return;
     }
-    let c = measure::instructions(&subject())
+    let c = measure::instructions(&subject(), None)
         .expect("cachegrind invocation failed")
         .expect("valgrind present but no I refs parsed");
 
@@ -69,7 +69,7 @@ fn instruction_counts_are_deterministic() {
     // across separate invocations too, not just within one.
     let outer: Vec<_> = (0..2)
         .map(|_| {
-            measure::instructions(&cmd)
+            measure::instructions(&cmd, None)
                 .expect("cachegrind invocation failed")
                 .expect("no I refs parsed")
         })
@@ -98,11 +98,11 @@ fn availability_and_failure_are_distinct() {
         // vanish, so this must be an error rather than Ok(None).
         let bogus = vec!["/nonexistent/tak-not-a-real-binary".to_string()];
         assert!(
-            measure::instructions(&bogus).is_err(),
+            measure::instructions(&bogus, None).is_err(),
             "a failed measurement must not look like a missing valgrind"
         );
     } else {
-        assert!(measure::instructions(&subject()).unwrap().is_none());
+        assert!(measure::instructions(&subject(), None).unwrap().is_none());
     }
 }
 
@@ -113,7 +113,8 @@ fn missing_valgrind_is_not_an_error() {
         eprintln!("skipping: valgrind is installed, cannot test its absence");
         return;
     }
-    let got = measure::instructions(&subject()).expect("must not error when valgrind is absent");
+    let got =
+        measure::instructions(&subject(), None).expect("must not error when valgrind is absent");
     assert!(got.is_none());
 }
 
@@ -124,6 +125,7 @@ fn wall_clock_works_without_counters() {
         cmd: subject(),
         warmup: 1,
         runs: 3,
+        dir: None,
     })
     .expect("wall measurement failed");
 


### PR DESCRIPTION
`tak run` with no command now runs whatever `tak.toml` declares, searching upward from the working directory so it behaves the same from a subdirectory as from the repository root.

```toml
[bench.startup]
cmd = ["./target/release/mycli", "--version"]

[bench.help]
cmd = "mycli --help"    # split on whitespace; there is no shell
runs = 10
```

## Why this matters more than convenience

CI and a laptop have to measure the *same thing*. A command line living in a workflow file drifts from the one people run locally, and the numbers quietly stop being comparable — which for a tool whose entire claim is trustworthy measurement is the failure that counts.

It is also what aube needs to adopt tak without a sprawling CI invocation.

## `tak.toml`, not `bench.toml`

`bench.toml` was my working name and it was wrong. Gates, runner classes and competitor definitions all belong in this file too, so it would have been misnamed the moment the first landed — and it is generic enough that another benchmarking tool could reasonably want it. Every config in this ecosystem is tool-named: `mise.toml`, `hk.pkl`, `release-plz.toml`, `cliff.toml`.

## Details worth reviewing

**A string command gets no shell semantics** — split on whitespace and nothing else. Spawning a shell adds its own startup cost and variance to every sample, which for 10ms commands is a large fraction of the measurement. Anything needing a pipe should be a list whose first element is the interpreter. There's a test pinning that `"mycli 'two words'"` splits into three arguments rather than quietly appearing to quote.

**An explicit command after `--` always wins**, so ad-hoc measurement never depends on repository state.

**Declared commands are validated at load**, not partway through a run that has already spent minutes measuring.

**Defaults match the CLI's** (20 runs, 3 warmup), so moving a command into `tak.toml` doesn't silently change what it measures.

## Verified

```
$ tak run                      # both declared benchmarks, alphabetical
$ tak run --bench help         # one
$ tak run -- /bin/echo hi      # ad-hoc wins
$ tak run --bench nope
Error: no benchmark `nope` in /home/coder/src/tak/tak.toml (found: help, version)
```

34 tests, `fmt` and `clippy -D warnings` clean. Includes a `tak.toml` for tak itself.

Also gitignores `.claude/` — a worktree in there was getting picked up as an embedded git repository.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New optional config path and CLI behavior; measurement/recording semantics are tightened (batch record, working directory) but do not touch auth or external services.
> 
> **Overview**
> Adds **`tak.toml`** so CI and local runs can share the same declared benchmarks instead of duplicating command lines in workflows.
> 
> **`tak run`** with no command after `--` walks up from the cwd, loads `tak.toml`, and runs all `[bench.*]` entries in stable name order (or **`--bench name`** for one). A command after `--` still wins for ad-hoc runs. **`--runs` / `--warmup`** are optional and override per-bench file values when set.
> 
> New **`src/config`** parses TOML (`cmd` as argv list or whitespace-split string, no shell), validates commands at load time, and applies the same default runs/warmup as the CLI. Measurement runs with **`Plan.dir`** set to the config file’s directory so relative paths like `./target/release/tak` resolve consistently; **`--record`** batches all benchmarks into one git-notes append so a failed later bench does not leave a partial record set.
> 
> Also adds a repo **`tak.toml`** for `version`/`help`, **`toml`** dependency, README docs, `.claude/` in **`.gitignore`**, and rejects **`runs: 0`** in wall timing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c842ab72211fc53bbdc1c8a40e669e447d229a3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->