### PR TITLE
ci: drop x86_64-apple-darwin from the release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,7 @@ jobs:
             os: ubuntu-latest
           - target: aarch64-unknown-linux-musl
             os: ubuntu-latest
-          - target: x86_64-apple-darwin
-            os: macos-latest
+          # No x86_64-apple-darwin: Intel Macs are not a target we publish for.
           - target: aarch64-apple-darwin
             os: macos-latest
           - target: x86_64-pc-windows-msvc

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,7 +2,7 @@
 
 Releases are automated with [release-plz](https://release-plz.dev). Merge to `main`, and
 release-plz opens a release PR that bumps versions and writes the changelog. Merging *that*
-tags, publishes to crates.io, builds binaries for eight targets, attaches them, and publishes
+tags, publishes to crates.io, builds binaries for seven targets, attaches them, and publishes
 the GitHub release.
 
 The release stays a draft until its binaries are attached, so it never appears without them.
@@ -34,7 +34,7 @@ trigger other workflows, so the release PR it opened would never run CI.
 gh workflow run release.yml -f tag=v0.1.0
 ```
 
-Builds all eight targets, attaches them with `--clobber`, and publishes the release. It is
+Builds all seven targets, attaches them with `--clobber`, and publishes the release. It is
 idempotent. The tag and the GitHub release must already exist — release-plz creates both, and
 this workflow only rebuilds and reattaches.
 
@@ -47,15 +47,17 @@ only when they differ. "already up to date" means the published crate really is 
 
 ## Targets
 
-Eight targets. musl is not only about portability: `tak backfill` runs inside slim containers,
+Seven targets. musl is not only about portability: `tak backfill` runs inside slim containers,
 and a static binary needs no libc to match.
 
 ```
-x86_64-unknown-linux-gnu     x86_64-apple-darwin
-x86_64-unknown-linux-musl    aarch64-apple-darwin
-aarch64-unknown-linux-gnu    x86_64-pc-windows-msvc
-aarch64-unknown-linux-musl   aarch64-pc-windows-msvc
+x86_64-unknown-linux-gnu     aarch64-apple-darwin
+x86_64-unknown-linux-musl    x86_64-pc-windows-msvc
+aarch64-unknown-linux-gnu    aarch64-pc-windows-msvc
+aarch64-unknown-linux-musl
 ```
+
+macOS is Apple Silicon only. Intel Macs are not a target we publish for.
 
 `SHA256SUMS` is attached alongside. `tak backfill` skips checksum sidecars when choosing an
 asset, so this costs nothing downstream.


### PR DESCRIPTION
Intel Macs are no longer a target we publish for, so building and attaching that binary costs a matrix job per release and adds an asset nobody downloads.

macOS is now Apple Silicon only. **Seven targets remain:**

```
x86_64-unknown-linux-gnu     aarch64-apple-darwin
x86_64-unknown-linux-musl    x86_64-pc-windows-msvc
aarch64-unknown-linux-gnu    aarch64-pc-windows-msvc
aarch64-unknown-linux-musl
```

`RELEASING.md` is updated in the same commit — it stated "eight targets" in three places and listed the target grid, all of which would have gone stale.

## Notes

- The matrix keeps a comment where the target was, so the omission reads as deliberate rather than as something that fell out during an edit.
- Nothing else references the removed target. The `x86_64-apple-darwin` strings in `crates/asset-picker` and `src/backfill.rs` are test fixtures for *other* projects' release assets and are unrelated.
- v0.0.2 already shipped with the Intel binary attached; this takes effect from the next release.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release packaging and documentation only; no runtime or auth changes, and existing Apple Silicon/macOS/Windows/Linux targets are unchanged.
> 
> **Overview**
> Stops publishing **Intel macOS** binaries by removing the `x86_64-apple-darwin` job from the `release.yml` build matrix, leaving **seven** release targets (macOS is **Apple Silicon only** via `aarch64-apple-darwin`).
> 
> **`RELEASING.md`** is updated to match: "eight targets" → seven, the target grid is rearranged, and a short note explains that Intel Macs are out of scope. A comment in the workflow marks the omission as intentional.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a02e0f9944fde774f3e587dd536f40e73f52b242. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->