### PR TITLE
ci: generate release notes with communique

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -71,6 +71,43 @@ jobs:
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "tak-cli tag: ${tag:-<none released>}"
 
+  # release-plz writes the body from commit subjects via cliff.toml. communique
+  # replaces it with prose written from the commits, PRs and diffs. It runs
+  # against the draft, in parallel with the seven binary builds, so the raw
+  # version is never visible and the rewrite costs no extra wall clock.
+  #
+  # Nothing here is worth holding a release for: the cliff.toml notes are
+  # already on the draft and perfectly serviceable. `continue-on-error` at the
+  # job level — rather than on the communique step — so an install or checkout
+  # failure is survivable too. The job still shows as failed, it just does not
+  # block `publish-release`.
+  enhance-release:
+    name: Enhance release notes
+    needs: release-plz-release
+    if: ${{ needs.release-plz-release.outputs.tag != '' }}
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # communique diffs the new tag against the previous one, so it needs
+          # the tags and the history between them.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+
+      # The token has to be the PAT: the /releases/tags endpoint hides drafts,
+      # so communique falls back to listing releases, which needs write access.
+      - name: Rewrite the release body with communique
+        env:
+          TAG: ${{ needs.release-plz-release.outputs.tag }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: communique generate "$TAG" --github-release
+
   # Binaries are attached to the draft, then the draft is published — so a
   # release is never visible without its assets.
   upload-assets:
@@ -85,7 +122,7 @@ jobs:
 
   publish-release:
     name: Publish release
-    needs: [release-plz-release, upload-assets]
+    needs: [release-plz-release, upload-assets, enhance-release]
     if: ${{ needs.release-plz-release.outputs.tag != '' }}
     runs-on: ubuntu-latest
     permissions:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,10 +2,25 @@
 
 Releases are automated with [release-plz](https://release-plz.dev). Merge to `main`, and
 release-plz opens a release PR that bumps versions and writes the changelog. Merging *that*
-tags, publishes to crates.io, builds binaries for seven targets, attaches them, and publishes
-the GitHub release.
+tags, publishes to crates.io, builds binaries for seven targets, attaches them, rewrites the
+release notes, and publishes the GitHub release.
 
-The release stays a draft until its binaries are attached, so it never appears without them.
+The release stays a draft until its binaries are attached and its notes are written, so it
+never appears half-finished.
+
+## Release notes
+
+`release-plz` writes the release body from commit subjects using `cliff.toml`.
+[communique](https://github.com/jdx/communique) then rewrites it into prose from the commits,
+pull requests and diffs, in the `enhance-release` job. It runs while the release is still a
+draft and in parallel with the binary builds, so it costs no wall clock and the raw version is
+never visible.
+
+Tone and project context live in `communique.toml`. The tool version is pinned in `mise.toml` —
+that is the only thing mise is used for in this repository.
+
+The job is `continue-on-error`, so if generation fails the release still publishes, with the
+`cliff.toml` notes intact.
 
 ## Crates
 
@@ -24,9 +39,12 @@ Each crate has a Trusted Publisher on crates.io pointing at `jdx/tak` and the wo
 filename `release-plz.yml`. **Renaming that workflow breaks publishing** until the trusted
 publisher is updated to match.
 
-The only stored secret is `RELEASE_PLZ_TOKEN`, a PAT with `contents: write` and
-`pull-requests: write`. The built-in `GITHUB_TOKEN` cannot be used: events it raises do not
-trigger other workflows, so the release PR it opened would never run CI.
+Two secrets are stored:
+
+| secret | used by | why |
+|---|---|---|
+| `RELEASE_PLZ_TOKEN` | `release-plz.yml` | A PAT with `contents: write` and `pull-requests: write`. The built-in `GITHUB_TOKEN` cannot be used: events it raises do not trigger other workflows, so the release PR it opened would never run CI. communique also needs it to read the *draft* release — the `/releases/tags` endpoint hides drafts, so it falls back to listing releases, which requires write access. |
+| `ANTHROPIC_API_KEY` | `release-plz.yml` (`enhance-release`) | communique's model calls. Without it, note generation fails and the release publishes with the `cliff.toml` body. |
 
 ## Building a release by hand
 

--- a/communique.toml
+++ b/communique.toml
@@ -1,0 +1,22 @@
+context = """
+tak measures how much work a command does by counting instructions with cachegrind, instead of
+timing it. Wall clock on a shared CI runner has a 10-20% noise floor — the same size as the
+regressions people want to catch — while instruction counts move by hundredths of a percent
+under heavy contention. So CI can gate on them. Results live in the repository itself, in
+refs/notes/tak, with no database or service behind it.
+
+The installed binary is `tak`; the crate is `tak-cli`, because bare `tak` on crates.io is a
+dormant 2016 board-game implementation. The workspace also publishes `asset-picker`, the
+release-asset selection library extracted from mise, which gets no GitHub release of its own.
+"""
+
+system_extra = """
+tak is an unfinished experiment and says so in a large box at the top of its README: no
+stability guarantees, no roadmap, interfaces change without warning. Match that. Do not write
+upgrade recommendations, do not imply production readiness, and do not use marketing language
+about what the release unlocks. Describe what changed and why, and let breaking changes read as
+the ordinary events they are here.
+"""
+
+[defaults]
+emoji = false

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,5 @@
+[tools]
+# Used by the enhance-release job in .github/workflows/release-plz.yml to
+# rewrite the generated release body. Not needed to build or test tak — the
+# Rust toolchain comes from rust-toolchain in CI and rustup locally.
+communique = "latest"


### PR DESCRIPTION
release-plz writes the release body from commit subjects via `cliff.toml`. [communique](https://github.com/jdx/communique) rewrites it into prose from the commits, PRs and diffs — the same setup as fnox, hk, pklr and pitchfork. tak was the only one of them without it.

### Where it runs

tak drafts its releases, so placement matters. The new `enhance-release` job runs after the tag exists but **before** `publish-release` undrafts, and in parallel with the seven binary builds. The raw cliff.toml body is therefore never publicly visible, and the rewrite adds no wall clock.

`publish-release` now waits on it.

### Two decisions worth reviewing

**`continue-on-error` at the job level, not the step level.** A note-generation failure should not strand a release as a permanent draft. Job level rather than step level so a mise-install or checkout failure is survivable too — the job still shows as failed, it just doesn't block publishing, and the cliff.toml notes are already on the draft.

**`RELEASE_PLZ_TOKEN` rather than `GITHUB_TOKEN`.** `/releases/tags/{tag}` hides drafts, so communique falls back to listing releases, which needs write access.

### Files

- `communique.toml` — project context, and a `system_extra` telling it to match the README's "unfinished experiment" stance instead of writing upgrade recommendations. `emoji = false`, as elsewhere.
- `mise.toml` — new. Pins `communique` and nothing else; the Rust toolchain still comes from `dtolnay/rust-toolchain`.

### Before merging

Needs an `ANTHROPIC_API_KEY` secret on the repository. Without it the job fails and releases publish with the cliff.toml body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release automation only; failures are non-blocking and releases still publish with cliff.toml notes.
> 
> **Overview**
> Adds an **`enhance-release`** job to the release-plz workflow that runs **communique** against the draft GitHub release (in parallel with binary uploads) to replace the `cliff.toml` body with prose from commits, PRs, and diffs. **`publish-release`** now depends on that job so undrafting happens after the rewrite attempt.
> 
> The job uses **`continue-on-error`** so checkout/mise/communique failures do not block publishing; releases fall back to the existing cliff notes. **`RELEASE_PLZ_TOKEN`** is required for communique to reach draft releases (not `GITHUB_TOKEN`).
> 
> New **`communique.toml`** supplies project context and an “unfinished experiment” tone (`emoji = false`). **`mise.toml`** pins communique for CI only. **`RELEASING.md`** documents the flow and the new **`ANTHROPIC_API_KEY`** secret.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8c7d38c11719a2a84ada2499a01424f9a2a2f15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->