### PR TITLE
ci: release on a seven-day cadence instead of on every merge

### DIFF
--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -1,0 +1,90 @@
+name: auto-merge-release
+
+# Releases tak on a cadence rather than on every merge: once a day this looks
+# for release-plz's open release PR and merges it, but only if the last release
+# is at least seven days old and something user-visible has landed since.
+#
+# Merging that PR is what triggers release-plz.yml's release job, so this is the
+# whole release trigger — nothing else merges it.
+
+on:
+  schedule:
+    - cron: "0 10 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: auto-merge-release
+  cancel-in-progress: false
+
+jobs:
+  merge:
+    if: github.repository == 'jdx/tak'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+
+      - name: Merge the release PR
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [ "${GITHUB_EVENT_NAME:-}" != "workflow_dispatch" ]; then
+            latest_tag=$(git describe --tags --match 'v[0-9]*' --abbrev=0 || true)
+            if [ -n "$latest_tag" ]; then
+              range="${latest_tag}..HEAD"
+              tag_time=$(git for-each-ref --format='%(creatordate:unix)' "refs/tags/$latest_tag")
+              now=$(date +%s)
+              min_age=$((7 * 24 * 60 * 60))
+              age=$((now - tag_time))
+              if [ "$age" -lt "$min_age" ]; then
+                echo "Latest release ${latest_tag} is less than 7 days old; not auto-merging release PRs"
+                exit 0
+              fi
+            else
+              # Nothing to measure a cadence against yet — let the first
+              # release through rather than deadlocking on a missing tag.
+              echo "No v[0-9]* release tag found; allowing bootstrap release"
+              range=""
+            fi
+            # Docs, CI and chore commits do not move a version anyone installs.
+            if [ -n "$range" ]; then
+              commit_subjects=$(git log --format=%s "$range")
+              if ! grep -Eq '^(fix|feat)(\([^)]+\))?!?: ' <<<"$commit_subjects"; then
+                echo "No pending fix/feat commits since the latest release; not auto-merging release PRs"
+                exit 0
+              fi
+            fi
+          else
+            echo "Manual dispatch; skipping release cadence guards"
+          fi
+
+          # release-plz opens its PR from `release-plz-<base>`. Match on that
+          # prefix and on the PR coming from this repository, so a fork branch
+          # of the same name can never be what gets merged.
+          PR_NUMBER=$(gh pr list -R jdx/tak --base main --state open --limit 100 --json number,headRefName,headRepositoryOwner,title,updatedAt \
+            --jq '[.[] | select(.headRefName | startswith("release-plz-")) | select(.headRepositoryOwner.login == "jdx") | select(.title | startswith("chore: release"))] | sort_by(.updatedAt) | reverse | .[0].number // empty')
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No open release-plz release PR to main"
+            exit 0
+          fi
+
+          # An empty body means release-plz was still writing the PR when this
+          # ran. The changelog would be wrong; wait for tomorrow instead.
+          BODY=$(gh pr view "$PR_NUMBER" -R jdx/tak --json body --jq '.body // ""')
+          TRIMMED_BODY=$(echo "$BODY" | tr -d '[:space:]')
+          if [ -z "$TRIMMED_BODY" ]; then
+            echo "Skipping merge: PR #$PR_NUMBER has an empty body; will retry on the next scheduled run"
+            exit 0
+          fi
+
+          echo "PR #$PR_NUMBER is ready for the daily release window"
+          gh pr merge "$PR_NUMBER" -R jdx/tak --squash --auto

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,6 +8,21 @@ release notes, and publishes the GitHub release.
 The release stays a draft until its binaries are attached and its notes are written, so it
 never appears half-finished.
 
+## Cadence
+
+Nobody merges the release PR by hand. `auto-merge-release.yml` runs daily at 10:00 UTC and
+merges it only if **both** hold:
+
+- the most recent `v*` tag is at least **seven days** old, and
+- at least one `fix:` or `feat:` commit has landed since it
+
+Docs, CI and chore commits therefore accumulate without producing a release. To release
+sooner, dispatch it manually — that skips both guards:
+
+```sh
+gh workflow run auto-merge-release.yml
+```
+
 ## Release notes
 
 `release-plz` writes the release body from commit subjects using `cliff.toml`.
@@ -43,7 +58,7 @@ Two secrets are stored:
 
 | secret | used by | why |
 |---|---|---|
-| `RELEASE_PLZ_TOKEN` | `release-plz.yml` | A PAT with `contents: write` and `pull-requests: write`. The built-in `GITHUB_TOKEN` cannot be used: events it raises do not trigger other workflows, so the release PR it opened would never run CI. communique also needs it to read the *draft* release — the `/releases/tags` endpoint hides drafts, so it falls back to listing releases, which requires write access. |
+| `RELEASE_PLZ_TOKEN` | `release-plz.yml`, `auto-merge-release.yml` | A PAT with `contents: write` and `pull-requests: write`. The built-in `GITHUB_TOKEN` cannot be used: events it raises do not trigger other workflows, so the release PR it opened would never run CI. communique also needs it to read the *draft* release — the `/releases/tags` endpoint hides drafts, so it falls back to listing releases, which requires write access. |
 | `ANTHROPIC_API_KEY` | `release-plz.yml` (`enhance-release`) | communique's model calls. Without it, note generation fails and the release publishes with the `cliff.toml` body. |
 
 ## Building a release by hand


### PR DESCRIPTION

Nothing merges release-plz's release PR today, so nothing releases on its own. This adds the daily auto-merge job aube, hk and usage already run.

### Guards

At 10:00 UTC it merges the open release PR, but only if **both** hold:

- the most recent `v*` tag is at least seven days old
- at least one `fix:` or `feat:` commit has landed since it

So docs, CI and chore commits accumulate without cutting a release. `workflow_dispatch` skips both guards — that's the manual release path.

### Why aube's variant and not hk's

hk and usage match `--head release`, because they drive release-plz through a mise task that force-pushes a branch literally named `release`. tak uses the action, whose PR branch is `release-plz-main`. So this uses aube's jq filter: match on the `release-plz-` prefix, and on the PR originating from this repository — a fork branch of the same name can never be what gets merged.

The empty-body check is also carried over: an empty body means release-plz was still writing the PR when the job ran, and the changelog would be wrong. It waits for the next day rather than merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
