### PR TITLE
fix: stop a push from erasing the remote's measurements

### DIFF
--- a/src/notes.rs
+++ b/src/notes.rs
@@ -21,8 +21,30 @@ use std::process::Command;
 use crate::record::{Record, parse_note};
 
 pub const NOTES_REF: &str = "refs/notes/tak";
-/// Force refspec: the local copy is a cache of the remote, never a divergent branch.
-const REFSPEC: &str = "+refs/notes/tak:refs/notes/tak";
+
+/// Scratch ref the remote is fetched into, so a fetch never lands directly on
+/// the ref holding records that have not been pushed yet.
+const REMOTE_REF: &str = "refs/notes/tak-remote";
+
+/// Refspec for reading. Forced, which is safe because it only ever overwrites
+/// the scratch ref.
+const FETCH_REFSPEC: &str = "+refs/notes/tak:refs/notes/tak-remote";
+
+/// Refspec for writing, deliberately **not** forced.
+///
+/// A forced push always succeeds. That makes the retry-and-merge loop below
+/// unreachable and lets any writer with a stale or empty local ref replace the
+/// entire remote history in one shot. It is not a hypothetical: a CI job whose
+/// checkout had never fetched notes recorded one measurement, pushed, and
+/// destroyed 60 backfilled ones in jdx/aube.
+///
+/// Without the `+`, that push is rejected as a non-fast-forward, and the loop
+/// fetches the remote, merges it in with cat_sort_uniq, and tries again.
+const PUSH_REFSPEC: &str = "refs/notes/tak:refs/notes/tak";
+
+/// Refspec suggested to users for plain `git fetch`, which has no local records
+/// to lose because it is a read-only convenience for people who never run tak.
+const USER_FETCH_REFSPEC: &str = "+refs/notes/tak:refs/notes/tak";
 /// Number of fetch/merge/push attempts before giving up on a contended push.
 const PUSH_ATTEMPTS: u32 = 5;
 
@@ -95,8 +117,38 @@ fn git_ok(args: &[&str]) -> Result<(bool, String)> {
 /// Never fatal: a developer may be offline, or the remote may have no notes yet.
 /// Callers fall back to whatever is in the local ref.
 pub fn fetch(remote: &str) -> Result<bool> {
-    let (ok, _) = git_ok(&["fetch", "--quiet", "--depth", "1", remote, REFSPEC])?;
-    Ok(ok)
+    let (ok, _) = git_ok(&["fetch", "--quiet", "--depth", "1", remote, FETCH_REFSPEC])?;
+    if !ok {
+        return Ok(false);
+    }
+    absorb_remote()?;
+    Ok(true)
+}
+
+/// Fold the fetched remote notes into the local ref, keeping both sides.
+///
+/// Reading used to fetch straight onto `refs/notes/tak`, so `tak history` after
+/// a local `tak run --record` threw the local record away before it could be
+/// pushed. Merging instead of overwriting is the same choice the push path
+/// makes, for the same reason: neither side of this ref is authoritative.
+fn absorb_remote() -> Result<()> {
+    // Nothing local yet: adopt the remote wholesale. `notes merge` needs a ref
+    // to merge into and would fail here.
+    let (has_local, _) = git_ok(&["rev-parse", "--verify", "--quiet", NOTES_REF])?;
+    if !has_local {
+        git(&["update-ref", NOTES_REF, REMOTE_REF])?;
+        return Ok(());
+    }
+    git_committing(&[
+        "notes",
+        "--ref",
+        NOTES_REF,
+        "merge",
+        "-s",
+        "cat_sort_uniq",
+        REMOTE_REF,
+    ])?;
+    Ok(())
 }
 
 /// Read every record attached to `commit`, after refreshing from the remote.
@@ -155,7 +207,7 @@ pub fn append(commit: &str, records: &[Record]) -> Result<()> {
 /// runners' measurements survive the merge.
 pub fn push(remote: &str) -> Result<()> {
     for attempt in 1..=PUSH_ATTEMPTS {
-        let (ok, err) = git_ok(&["push", "--quiet", remote, REFSPEC])?;
+        let (ok, err) = git_ok(&["push", "--quiet", remote, PUSH_REFSPEC])?;
         if ok {
             return Ok(());
         }
@@ -163,21 +215,8 @@ pub fn push(remote: &str) -> Result<()> {
             bail!("could not push {NOTES_REF} after {PUSH_ATTEMPTS} attempts: {err}");
         }
         // Fetch the winner's ref to a scratch location, then merge into ours.
-        git(&[
-            "fetch",
-            "--quiet",
-            remote,
-            "+refs/notes/tak:refs/notes/tak-remote",
-        ])?;
-        git_committing(&[
-            "notes",
-            "--ref",
-            NOTES_REF,
-            "merge",
-            "-s",
-            "cat_sort_uniq",
-            "refs/notes/tak-remote",
-        ])?;
+        git(&["fetch", "--quiet", remote, FETCH_REFSPEC])?;
+        absorb_remote()?;
     }
     unreachable!()
 }
@@ -193,9 +232,9 @@ pub fn rev_parse(rev: &str) -> Result<String> {
 pub fn install_refspec(remote: &str) -> Result<()> {
     let key = format!("remote.{remote}.fetch");
     let (_, existing) = git_ok(&["config", "--get-all", &key])?;
-    if existing.lines().any(|l| l.trim() == REFSPEC) {
+    if existing.lines().any(|l| l.trim() == USER_FETCH_REFSPEC) {
         return Ok(());
     }
-    git(&["config", "--add", &key, REFSPEC])?;
+    git(&["config", "--add", &key, USER_FETCH_REFSPEC])?;
     Ok(())
 }

--- a/tests/notes_race.rs
+++ b/tests/notes_race.rs
@@ -1,0 +1,217 @@
+//! Two writers must not be able to delete each other's measurements.
+//!
+//! This exists because they could. The push refspec was `+refs/notes/tak:…`,
+//! and a forced push always succeeds — so the retry-and-merge loop was
+//! unreachable, and a writer whose local ref was empty replaced the entire
+//! remote history. In jdx/aube a CI job whose checkout had never fetched notes
+//! recorded one measurement, pushed, and destroyed 60 backfilled ones.
+//!
+//! Nothing in the unit tests could see it: the bug lived in the interaction
+//! between two clones and a remote, which is exactly the shape these tests set
+//! up.
+
+use std::path::Path;
+use std::process::Command;
+
+fn git(dir: &Path, args: &[&str]) -> String {
+    let out = Command::new("git")
+        .args(["-c", "user.name=tak-test", "-c", "user.email=t@example.com"])
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .unwrap_or_else(|e| panic!("git {args:?} failed to spawn: {e}"));
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim_end().to_string()
+}
+
+fn tak(dir: &Path, args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_tak"))
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("failed to run tak")
+}
+
+/// Record a measurement under `bench` on HEAD, without measuring anything real.
+fn record(dir: &Path, bench: &str) {
+    let out = tak(
+        dir,
+        &[
+            "run",
+            "--no-counters",
+            "--runs",
+            "1",
+            "--warmup",
+            "0",
+            "--record",
+            "--bench",
+            bench,
+            "--",
+            "true",
+        ],
+    );
+    assert!(
+        out.status.success(),
+        "tak run failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// Which benchmarks the remote holds notes for, across every annotated commit.
+fn benches_on_remote(scratch: &Path, remote: &Path) -> Vec<String> {
+    let probe = scratch.join("probe");
+    if probe.exists() {
+        std::fs::remove_dir_all(&probe).unwrap();
+    }
+    git(
+        scratch,
+        &["clone", "--quiet", remote.to_str().unwrap(), "probe"],
+    );
+    // Fetch may find nothing if no notes were ever pushed; that is a valid state.
+    Command::new("git")
+        .args(["fetch", "origin", "+refs/notes/tak:refs/notes/tak"])
+        .current_dir(&probe)
+        .output()
+        .ok();
+    let list = Command::new("git")
+        .args(["notes", "--ref", "tak", "list"])
+        .current_dir(&probe)
+        .output()
+        .unwrap();
+    let mut found = Vec::new();
+    for line in String::from_utf8_lossy(&list.stdout).lines() {
+        let Some(target) = line.split_whitespace().nth(1) else {
+            continue;
+        };
+        let show = Command::new("git")
+            .args(["notes", "--ref", "tak", "show", target])
+            .current_dir(&probe)
+            .output()
+            .unwrap();
+        for record in String::from_utf8_lossy(&show.stdout).lines() {
+            if let Some(rest) = record.split("\"bench\":\"").nth(1)
+                && let Some(name) = rest.split('"').next()
+            {
+                found.push(name.to_string());
+            }
+        }
+    }
+    found.sort();
+    found.dedup();
+    found
+}
+
+/// Set up a bare remote with one commit, and return (scratch, remote).
+fn remote_with_a_commit(tag: &str) -> (std::path::PathBuf, std::path::PathBuf) {
+    let scratch = std::env::temp_dir().join(format!("tak-race-{tag}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&scratch);
+    std::fs::create_dir_all(&scratch).unwrap();
+
+    let remote = scratch.join("remote.git");
+    git(
+        &scratch,
+        // -b main: a bare repo defaults HEAD to `master`, and cloning it after
+        // pushing `main` leaves the clone with no HEAD to record against.
+        &[
+            "init",
+            "--quiet",
+            "--bare",
+            "-b",
+            "main",
+            remote.to_str().unwrap(),
+        ],
+    );
+
+    let seed = scratch.join("seed");
+    git(
+        &scratch,
+        &["clone", "--quiet", remote.to_str().unwrap(), "seed"],
+    );
+    git(&seed, &["commit", "--quiet", "--allow-empty", "-m", "seed"]);
+    git(
+        &seed,
+        &["push", "--quiet", "origin", "HEAD:refs/heads/main"],
+    );
+
+    (scratch, remote)
+}
+
+/// The exact shape of the aube incident: one clone pushes, a second clone that
+/// never fetched notes pushes its own, and the first clone's records must
+/// survive.
+#[test]
+fn a_second_writer_does_not_erase_the_first() {
+    let (scratch, remote) = remote_with_a_commit("second");
+
+    let a = scratch.join("a");
+    git(
+        &scratch,
+        &["clone", "--quiet", remote.to_str().unwrap(), "a"],
+    );
+    record(&a, "from-a");
+    assert!(tak(&a, &["push"]).status.success());
+
+    // B is a fresh clone. Like a CI checkout, it has no notes ref at all.
+    let b = scratch.join("b");
+    git(
+        &scratch,
+        &["clone", "--quiet", remote.to_str().unwrap(), "b"],
+    );
+    assert!(
+        !b.join(".git/refs/notes/tak").exists(),
+        "a plain clone should not have the notes ref"
+    );
+    record(&b, "from-b");
+    let out = tak(&b, &["push"]);
+    assert!(
+        out.status.success(),
+        "second push failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let found = benches_on_remote(&scratch, &remote);
+    std::fs::remove_dir_all(&scratch).ok();
+    assert_eq!(
+        found,
+        ["from-a", "from-b"],
+        "the second writer erased the first"
+    );
+}
+
+/// Reading must not discard local records either. `fetch` used to land straight
+/// on `refs/notes/tak`, so `tak history` between recording and pushing threw the
+/// measurement away — the same overwrite, one step earlier.
+#[test]
+fn reading_does_not_discard_unpushed_records() {
+    let (scratch, remote) = remote_with_a_commit("read");
+
+    let a = scratch.join("a");
+    git(
+        &scratch,
+        &["clone", "--quiet", remote.to_str().unwrap(), "a"],
+    );
+    record(&a, "from-a");
+    assert!(tak(&a, &["push"]).status.success());
+
+    let b = scratch.join("b");
+    git(
+        &scratch,
+        &["clone", "--quiet", remote.to_str().unwrap(), "b"],
+    );
+    record(&b, "from-b");
+    // Reading fetches. Before the fix this replaced B's local note with A's.
+    assert!(tak(&b, &["history"]).status.success());
+    assert!(tak(&b, &["push"]).status.success());
+
+    let found = benches_on_remote(&scratch, &remote);
+    std::fs::remove_dir_all(&scratch).ok();
+    assert_eq!(
+        found,
+        ["from-a", "from-b"],
+        "reading threw away the unpushed record"
+    );
+}


### PR DESCRIPTION
**This destroyed real data today.** In jdx/aube a `perf.yml` job recorded one measurement and pushed, and the 60 backfilled measurements already on the remote were gone. The push logged `pushed refs/notes/tak to origin` and exited 0.

## Cause

```rust
const REFSPEC: &str = "+refs/notes/tak:refs/notes/tak";
```

One refspec served both fetch and push, and it was forced. A forced push always succeeds — so the retry-and-merge loop right underneath it was **unreachable dead code**, and any writer whose local ref was stale or empty replaced the whole remote history.

A CI checkout is exactly that writer. `actions/checkout` does not fetch notes, so the job's local ref held one note. Force-pushing it replaced 60.

Reading had the same shape one step earlier: `fetch` landed directly on `refs/notes/tak`, so `tak history` between recording and pushing threw the local record away.

## Fix

| | |
|---|---|
| `PUSH_REFSPEC` | `refs/notes/tak:refs/notes/tak` — **not** forced, so a non-fast-forward is rejected and the merge path finally runs |
| `FETCH_REFSPEC` | `+refs/notes/tak:refs/notes/tak-remote` — forced, but only ever onto a scratch ref |
| both paths | merge into the local ref with `cat_sort_uniq`, adopting the remote wholesale when there is nothing local yet |

`tak init`'s suggested refspec for plain `git fetch` keeps the forced form: it is a read-only convenience for people who never run tak, so it has no local records to lose.

## Tests

`tests/notes_race.rs` builds a real bare remote and two clones, because that is the only place these bugs exist. No unit test could see them — they live in the interaction between repositories, and every existing test passed the whole time.

| test | shape |
|---|---|
| `a_second_writer_does_not_erase_the_first` | the aube incident exactly: clone A pushes, fresh clone B (no notes ref, like a CI checkout) pushes, both must survive |
| `reading_does_not_discard_unpushed_records` | record locally, `tak history`, push — the local record must still be there |

**Verified they fail without the fix.** Reverting each refspec in turn:

```
assertion `left == right` failed: the second writer erased the first
  left: ["from-b"]                       <- from-a gone, exactly as in aube
 right: ["from-a", "from-b"]

assertion `left == right` failed: reading threw away the unpushed record
  left: ["from-a"]
 right: ["from-a", "from-b"]
```

67 tests pass, clippy `-D warnings` and fmt clean.

## Recovering aube

Nothing is permanently lost — release binaries are immutable, so re-running `perf-backfill` reproduces the 60 records byte-for-byte. But it must not be re-run until aube is on a tak that has this fix, or the next push to main will erase it again.

Order: merge this → release → bump aube's pinned `github:jdx/tak` → re-dispatch the backfill.

## What this says about the design

The retry-and-merge loop was written, reviewed and committed, and never executed once. It had no test because the failure it handles cannot occur inside a single repository. Same class of gap as `measure::instructions`, which shipped having never run because valgrind was absent from the machine — `tests/counters.rs` exists for that. This is that lesson a second time, and I did not apply it here.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes git notes sync semantics that previously caused production data loss; behavior is intentionally stricter on push but is the correct fix for concurrent CI writers.
> 
> **Overview**
> **Fixes data loss** when syncing benchmark notes: a single forced refspec for both fetch and push let CI jobs with an empty local notes ref **overwrite the entire remote** (the documented aube incident), and fetch-on-read could **wipe unpushed local records** before push.
> 
> **Push** now uses a **non-forced** `PUSH_REFSPEC` so stale writers get rejected and the existing retry loop can fetch, merge with `cat_sort_uniq`, and retry. **Fetch** lands on scratch `refs/notes/tak-remote` via `FETCH_REFSPEC`, then **`absorb_remote()`** merges into `refs/notes/tak` (or adopts remote when local is empty). Plain `git fetch` via `tak init` still suggests the forced `USER_FETCH_REFSPEC` for read-only users.
> 
> Adds **`tests/notes_race.rs`** integration tests (two clones + bare remote) for the second-writer and read-before-push scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 862f0a3a3bd6b4a7adb54cc4168510f4bf500aee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->