### PR TITLE
fix: stop a broken tak.toml reaching commands that ignore it

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -100,6 +100,37 @@ impl Config {
         Ok(cfg)
     }
 
+    /// Read only the `[env]` table, without validating benchmarks.
+    ///
+    /// Settings and benchmarks live in the same file but are needed at
+    /// different times. Resolving settings through [`Config::parse`] would make
+    /// a broken `[bench.x]` abort `tak run -- somecmd`, which does not read
+    /// benchmarks at all, and `tak settings`, which reads none of them either.
+    ///
+    /// Unknown keys are ignored, so `[bench]` is not even looked at here. A TOML
+    /// *syntax* error still fails: the file may carry `[env]` settings that
+    /// change what gets scrubbed from a subject's environment, and quietly
+    /// falling back to defaults would apply a weaker filter than the project
+    /// asked for without saying so.
+    pub fn find_env(start: &Path) -> Result<Option<EnvSection>> {
+        #[derive(Deserialize)]
+        struct EnvOnly {
+            #[serde(default)]
+            env: Option<EnvSection>,
+        }
+        for dir in start.ancestors() {
+            let path = dir.join(FILE_NAME);
+            if path.is_file() {
+                let text = std::fs::read_to_string(&path)
+                    .with_context(|| format!("could not read {}", path.display()))?;
+                let parsed: EnvOnly = toml::from_str(&text)
+                    .with_context(|| format!("could not parse {}", path.display()))?;
+                return Ok(parsed.env);
+            }
+        }
+        Ok(None)
+    }
+
     /// Find and load `tak.toml`, searching upward from `start`.
     ///
     /// Walking up means `tak run` behaves the same from a subdirectory as from

--- a/src/main.rs
+++ b/src/main.rs
@@ -572,19 +572,22 @@ fn cmd_backfill(
 
 /// Resolve settings from the CLI, the environment, and `tak.toml`.
 ///
-/// A *missing* `tak.toml` is fine — `tak run -- cmd` works in any directory, so
-/// settings must too. A *malformed* one is an error: swallowing the parse
-/// failure would have `tak settings` print defaults the project never asked
-/// for, with nothing to suggest its configuration had been skipped.
-fn resolve_settings(cli: &Cli) -> Result<Settings> {
-    let config = config::Config::find(&std::env::current_dir()?)
-        .context("could not read settings")?
-        .and_then(|(_, c)| c.env);
-    let overrides = Overrides {
-        env_deny: settings::from_cli(cli.env_deny.clone()),
-        env_allow: settings::from_cli(cli.env_allow.clone()),
-    };
-    Ok(Settings::from_process(&overrides, config.as_ref()))
+/// Called only by the commands that measure something or report settings.
+/// `push`, `init`, `history` and `doctor` do not consult `tak.toml` at all, so a
+/// broken one cannot stop you from pushing measurements you already took.
+///
+/// Reads the `[env]` table only, via [`Config::find_env`], so an invalid
+/// `[bench.x]` does not abort `tak run -- somecmd` — an explicit command has
+/// never depended on the declared benchmarks and still does not.
+///
+/// A *missing* `tak.toml` is fine. A *syntax-broken* one is an error even here:
+/// it may carry `[env]` settings that change what gets scrubbed from a
+/// subject's environment, and silently applying a weaker filter than the
+/// project asked for is not a good failure.
+fn resolve_settings(overrides: &Overrides) -> Result<Settings> {
+    let config =
+        config::Config::find_env(&std::env::current_dir()?).context("could not read settings")?;
+    Ok(Settings::from_process(overrides, config.as_ref()))
 }
 
 /// Print the settings registry with resolved values.
@@ -628,7 +631,10 @@ fn cmd_settings(resolved: &Settings, docs: bool) -> Result<()> {
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
-    let resolved = resolve_settings(&cli)?;
+    let overrides = Overrides {
+        env_deny: settings::from_cli(cli.env_deny),
+        env_allow: settings::from_cli(cli.env_allow),
+    };
     match cli.cmd {
         Cmd::Run {
             bench,
@@ -637,7 +643,15 @@ fn main() -> Result<()> {
             no_counters,
             record,
             cmd,
-        } => cmd_run(bench, runs, warmup, no_counters, record, cmd, &resolved),
+        } => cmd_run(
+            bench,
+            runs,
+            warmup,
+            no_counters,
+            record,
+            cmd,
+            &resolve_settings(&overrides)?,
+        ),
         Cmd::History { rev, remote } => cmd_history(rev, remote),
         Cmd::Push { remote } => {
             notes::push(&remote)?;
@@ -660,9 +674,18 @@ fn main() -> Result<()> {
             limit,
             runs,
             dry_run,
-        } => cmd_backfill(repo, bin, args, bench, limit, runs, dry_run, &resolved),
+        } => cmd_backfill(
+            repo,
+            bin,
+            args,
+            bench,
+            limit,
+            runs,
+            dry_run,
+            &resolve_settings(&overrides)?,
+        ),
         Cmd::Doctor => cmd_doctor(),
-        Cmd::Settings { docs } => cmd_settings(&resolved, docs),
+        Cmd::Settings { docs } => cmd_settings(&resolve_settings(&overrides)?, docs),
     }
 }
 

--- a/tests/settings_cli.rs
+++ b/tests/settings_cli.rs
@@ -66,6 +66,81 @@ fn every_setting_appears_in_the_listing() {
     );
 }
 
+/// Make a scratch directory holding exactly this `tak.toml`.
+fn dir_with_config(tag: &str, contents: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!("tak-cfg-{tag}-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("tak.toml"), contents).unwrap();
+    dir
+}
+
+fn run_in(dir: &std::path::Path, args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_tak"))
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("failed to run tak")
+}
+
+/// An explicit command has never depended on the declared benchmarks, and
+/// resolving settings must not quietly change that. A `[bench]` entry tak would
+/// reject is irrelevant to `tak run -- somecmd`.
+#[cfg(unix)]
+#[test]
+fn an_invalid_benchmark_does_not_block_an_ad_hoc_run() {
+    let dir = dir_with_config("badbench", "[bench.broken]\ncmd = []\n");
+    let out = run_in(
+        &dir,
+        &[
+            "run",
+            "--no-counters",
+            "--runs",
+            "1",
+            "--warmup",
+            "0",
+            "--",
+            "/bin/echo",
+            "hi",
+        ],
+    );
+    std::fs::remove_dir_all(&dir).ok();
+    assert!(
+        out.status.success(),
+        "an unrelated broken benchmark blocked an explicit run: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// Same reasoning for the settings listing: it reads `[env]`, not `[bench]`.
+#[test]
+fn an_invalid_benchmark_does_not_block_the_listing() {
+    let dir = dir_with_config("badbench2", "[bench.broken]\ncmd = []\n");
+    let out = run_in(&dir, &["settings"]);
+    std::fs::remove_dir_all(&dir).ok();
+    assert!(
+        out.status.success(),
+        "a broken benchmark blocked `tak settings`: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// Commands that measure nothing do not read `tak.toml` at all, so a file that
+/// cannot be parsed must not stand between you and pushing results you already
+/// have. `history` needs no network and no notes to exit cleanly.
+#[test]
+fn a_broken_config_does_not_block_commands_that_ignore_it() {
+    let dir = dir_with_config("syntax", "this is not toml at all\n");
+    // Not a git repository either, so this fails for git reasons if at all —
+    // what matters is that the failure is never about tak.toml.
+    let out = run_in(&dir, &["history"]);
+    std::fs::remove_dir_all(&dir).ok();
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("tak.toml"),
+        "a command that ignores tak.toml complained about it: {stderr}"
+    );
+}
+
 /// A malformed `tak.toml` must be reported, not silently replaced by defaults —
 /// otherwise `tak settings` confidently prints values the project did not ask
 /// for and gives no hint that its configuration was skipped.


### PR DESCRIPTION
**This fix was already reviewed and approved — it just never reached main.**

#18 squash-merged without commit `1b5092d`. That commit exists only on `origin/settings-env-filter` and `origin/scrub-subject-env`; `git branch -r --contains 1b5092d` does not list `origin/main`. I found it while building on top of `main` and discovering `Config::find_env` was not there.

So the "Ad-hoc run blocked by config" finding is **live on main and shipped in v0.0.3**, despite my having told you it was fixed. It was fixed on the branch; the branch content did not all land.

## What is wrong today

`resolve_settings` runs before dispatch for every subcommand and calls `Config::find`, which parses the whole file *and validates every benchmark*, and hard-errors on failure. So on current main:

```
$ cd a-repo-with-a-broken-bench
$ tak run -- ./mycli --version   # aborts
$ tak push                        # aborts
$ tak doctor                      # aborts
```

None of those read benchmarks. It also contradicts the guarantee written in `cmd_run`: *"An explicit command always wins; tak.toml is only consulted when none is given, so ad-hoc measurement never depends on repository state."*

## The restored fix

- **Resolution is lazy.** Only `run`, `backfill` and `settings` resolve. `push`, `init`, `history` and `doctor` never touch `tak.toml`.
- **Resolution reads only the setting tables**, via `Config::find_settings`, which ignores unknown keys. An invalid `[bench.x]` no longer blocks an explicit command or the listing.

A TOML *syntax* error still fails the commands that measure — the file may carry `[env]` settings deciding what is scrubbed from a subject's environment, and silently applying a weaker filter than the project asked for is worse than refusing.

## Verified

```
$ printf '[bench.broken]\ncmd = []\n' > tak.toml
  ad-hoc run: OK
  settings:   OK
```

70 tests pass, clippy `-D warnings` and fmt clean. The three tests from the original commit come with it.

## Note on the cherry-pick

It applied cleanly and **did not compile** — two dispatch call sites still referenced a variable the commit removes. Same trap as the earlier restack: a textually clean apply across a refactor is exactly where the build has to be run before pushing.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is scoped to config loading timing and partial parse; measurement paths still error on bad TOML syntax for `[env]`.
> 
> **Overview**
> **Settings resolution no longer loads or validates the whole `tak.toml` up front.** `resolve_settings` now uses `Config::find_env`, which only deserializes `[env]` and skips `[bench]`, so an invalid benchmark entry cannot fail `tak run -- cmd` or `tak settings`. TOML syntax errors still fail those paths so env scrubbing rules are not silently ignored.
> 
> **`tak.toml` is read only when a subcommand needs it.** `push`, `init`, `history`, and `doctor` no longer call `resolve_settings` at startup; only `run`, `backfill`, and `settings` do. A broken config file should not block pushing or inspecting history.
> 
> Integration tests cover invalid benchmarks not blocking ad-hoc runs and settings, and syntax errors not blocking `history`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70ea8e731cffd7b1c71fbdbb7abd5aedf7e804a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->