### PR TITLE
fix: fold the trend to one point per commit, and keep tool identity

### DIFF
--- a/src/compare.rs
+++ b/src/compare.rs
@@ -151,6 +151,62 @@ pub fn compare(base: &[Record], head: &[Record]) -> Comparison {
 /// Recent values for each series, oldest first.
 pub type Trend = BTreeMap<Key, Vec<f64>>;
 
+/// Assemble a trend from trunk history plus the revision under comparison.
+///
+/// `walked` is oldest-first, each entry a commit and the records attached to it.
+///
+/// The head's point is appended only when the walk did not already contain it.
+/// Appending unconditionally put it last even when it belongs in the middle —
+/// `tak compare v1.33.0 --rev v1.30.0` compares against an *ancestor*, and the
+/// line then ended on a value from earlier in the history while reading as
+/// though time ran left to right.
+pub fn build_trend(
+    walked: &[(String, Vec<Record>)],
+    head_sha: &str,
+    head_records: &[Record],
+) -> Trend {
+    let mut trend = Trend::new();
+    let mut head_in_history = false;
+    for (sha, records) in walked {
+        if sha == head_sha {
+            head_in_history = true;
+            // Its own measurements, in its own place in the timeline.
+            add_point(&mut trend, head_records);
+        } else {
+            add_point(&mut trend, records);
+        }
+    }
+    if !head_in_history {
+        add_point(&mut trend, head_records);
+    }
+    trend
+}
+
+/// Append one point per series, taking the minimum across a commit's records.
+///
+/// The minimum, matching how `compare` folds duplicates. A commit can carry
+/// several records for one series — a CI re-run, a retry — and taking each as
+/// its own point let a noisy re-run put a spike in the trend that the table,
+/// which reduces to the minimum, does not show.
+fn add_point(trend: &mut Trend, records: &[Record]) {
+    let mut lowest: BTreeMap<Key, f64> = BTreeMap::new();
+    for r in records {
+        if let Some(v) = r.metrics.get(GATED_METRIC) {
+            lowest
+                .entry((r.bench.clone(), r.tool.clone(), r.runner.clone()))
+                .and_modify(|e| {
+                    if v < e {
+                        *e = *v;
+                    }
+                })
+                .or_insert(*v);
+        }
+    }
+    for (key, value) in lowest {
+        trend.entry(key).or_default().push(value);
+    }
+}
+
 /// Eight levels of block, low to high.
 const BARS: [char; 8] = ['▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'];
 
@@ -387,6 +443,10 @@ fn outliers(c: &Comparison) -> String {
 mod tests {
     use super::*;
 
+    fn key(bench: &str) -> Key {
+        (bench.to_string(), "self".to_string(), "gha".to_string())
+    }
+
     fn rec(bench: &str, runner: &str, ins: f64, wall: f64) -> Record {
         Record {
             v: 1,
@@ -569,6 +629,48 @@ mod tests {
         let md = markdown(&c, &Trend::new(), 1.0, false);
         assert!(md.contains("`install` on `gha`"), "{md}");
         assert!(md.contains("`install` (pnpm) on `gha`"), "{md}");
+    }
+
+    /// The common case: the revision under comparison is a branch commit, so
+    /// it is not in trunk history and its point ends the line.
+    #[test]
+    fn a_branch_head_is_appended_last() {
+        let walked = vec![
+            ("c1".to_string(), vec![rec("a", "gha", 10.0, 1.0)]),
+            ("c2".to_string(), vec![rec("a", "gha", 20.0, 1.0)]),
+        ];
+        let t = build_trend(&walked, "branch", &[rec("a", "gha", 30.0, 1.0)]);
+        assert_eq!(t[&key("a")], vec![10.0, 20.0, 30.0]);
+    }
+
+    /// Comparing against an ancestor — `tak compare v1.33.0 --rev v1.30.0` —
+    /// puts the head *inside* the walked history. Appending it at the end as
+    /// well would draw a line that reads as time and is not in time order.
+    #[test]
+    fn a_head_inside_history_stays_in_its_place() {
+        let walked = vec![
+            ("c1".to_string(), vec![rec("a", "gha", 10.0, 1.0)]),
+            ("head".to_string(), vec![rec("a", "gha", 20.0, 1.0)]),
+            ("c3".to_string(), vec![rec("a", "gha", 30.0, 1.0)]),
+        ];
+        let t = build_trend(&walked, "head", &[rec("a", "gha", 99.0, 1.0)]);
+        assert_eq!(
+            t[&key("a")],
+            vec![10.0, 99.0, 30.0],
+            "the head's own measurement belongs where the head is, once"
+        );
+    }
+
+    /// Duplicate records within one commit collapse to the minimum, the same
+    /// rule the table uses — otherwise the two halves of a report disagree.
+    #[test]
+    fn a_commit_contributes_one_point() {
+        let walked = vec![(
+            "c1".to_string(),
+            vec![rec("a", "gha", 50.0, 1.0), rec("a", "gha", 10.0, 1.0)],
+        )];
+        let t = build_trend(&walked, "branch", &[]);
+        assert_eq!(t[&key("a")], vec![10.0]);
     }
 
     #[test]

--- a/src/compare.rs
+++ b/src/compare.rs
@@ -344,6 +344,21 @@ fn table(c: &Comparison, trend: &Trend, gate_pct: f64) -> String {
     out
 }
 
+/// How a series is named in prose: bench, plus the tool when it is not the
+/// project itself, plus the runner.
+///
+/// Dropping the tool made two series that differ only by tool render
+/// identically, so a report could say the same benchmark both started and
+/// stopped gating and mean two different programs.
+fn describe(key: &Key) -> String {
+    let (bench, tool, runner) = key;
+    if tool == "self" {
+        format!("`{bench}` on `{runner}`")
+    } else {
+        format!("`{bench}` ({tool}) on `{runner}`")
+    }
+}
+
 /// Series that exist on only one side. Always reported, including when nothing
 /// overlapped — that is the case where they matter most.
 fn outliers(c: &Comparison) -> String {
@@ -351,11 +366,7 @@ fn outliers(c: &Comparison) -> String {
     if !c.added.is_empty() {
         out.push_str(&format!(
             "\nNew, nothing to compare against: {}\n",
-            c.added
-                .iter()
-                .map(|(b, _, r)| format!("`{b}` on `{r}`"))
-                .collect::<Vec<_>>()
-                .join(", ")
+            c.added.iter().map(describe).collect::<Vec<_>>().join(", ")
         ));
     }
     if !c.removed.is_empty() {
@@ -364,7 +375,7 @@ fn outliers(c: &Comparison) -> String {
              running also stops gating: {}\n",
             c.removed
                 .iter()
-                .map(|(b, _, r)| format!("`{b}` on `{r}`"))
+                .map(describe)
                 .collect::<Vec<_>>()
                 .join(", ")
         ));
@@ -545,6 +556,19 @@ mod tests {
     fn zero_to_zero_is_not_a_regression() {
         let c = compare(&[rec("a", "gha", 0.0, 1.0)], &[rec("a", "gha", 0.0, 1.0)]);
         assert!(c.regressions(1.0).is_empty());
+    }
+
+    /// Two series that differ only by tool must not render identically, or the
+    /// report can say the same benchmark both started and stopped gating while
+    /// meaning two different programs.
+    #[test]
+    fn outliers_keep_their_tool() {
+        let mut pnpm = rec("install", "gha", 1.0, 1.0);
+        pnpm.tool = "pnpm".into();
+        let c = compare(&[], &[rec("install", "gha", 1.0, 1.0), pnpm]);
+        let md = markdown(&c, &Trend::new(), 1.0, false);
+        assert!(md.contains("`install` on `gha`"), "{md}");
+        assert!(md.contains("`install` (pnpm) on `gha`"), "{md}");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -394,46 +394,13 @@ const TREND_COMMITS: usize = 20;
 /// number that has drifted for weeks and a number this branch just moved look
 /// nothing alike, and the base-versus-head columns alone cannot tell them apart.
 fn gather_trend(base: &str, head_sha: &str, head_records: &[Record]) -> Result<compare::Trend> {
-    let mut trend: compare::Trend = std::collections::BTreeMap::new();
     let commits = notes::rev_list(base, TREND_COMMITS)?;
-
     // rev-list is newest first; a trend reads oldest to newest.
+    let mut walked = Vec::with_capacity(commits.len());
     for sha in commits.iter().rev() {
-        // Skip the head if the walk already covers it — otherwise its value is
-        // plotted twice and the line ends in a flat step that never happened.
-        if sha == head_sha {
-            continue;
-        }
-        add_point(&mut trend, &notes::read(None, sha)?);
+        walked.push((sha.clone(), notes::read(None, sha)?));
     }
-    add_point(&mut trend, head_records);
-    Ok(trend)
-}
-
-/// Append one point per series from a single commit's records.
-///
-/// The minimum, matching how `compare` folds duplicates. A commit can carry
-/// several records for one series — a CI re-run, a retry — and taking each of
-/// them as its own point let a noisy re-run put a spike in the trend that the
-/// table, which reduces to the minimum, does not show.
-fn add_point(trend: &mut compare::Trend, records: &[Record]) {
-    let mut lowest: BTreeMap<(String, String, String), f64> = BTreeMap::new();
-    for r in records {
-        if let Some(v) = r.metrics.get(compare::GATED_METRIC) {
-            let key = (r.bench.clone(), r.tool.clone(), r.runner.clone());
-            lowest
-                .entry(key)
-                .and_modify(|e| {
-                    if v < e {
-                        *e = *v;
-                    }
-                })
-                .or_insert(*v);
-        }
-    }
-    for (key, value) in lowest {
-        trend.entry(key).or_default().push(value);
-    }
+    Ok(compare::build_trend(&walked, head_sha, head_records))
 }
 
 /// Compare `rev` against `base`, print the report, and gate on it.

--- a/src/main.rs
+++ b/src/main.rs
@@ -393,29 +393,47 @@ const TREND_COMMITS: usize = 20;
 /// Reading the trunk and then the pull request in one line is the point: a
 /// number that has drifted for weeks and a number this branch just moved look
 /// nothing alike, and the base-versus-head columns alone cannot tell them apart.
-fn gather_trend(base: &str, head_records: &[Record]) -> Result<compare::Trend> {
+fn gather_trend(base: &str, head_sha: &str, head_records: &[Record]) -> Result<compare::Trend> {
     let mut trend: compare::Trend = std::collections::BTreeMap::new();
     let commits = notes::rev_list(base, TREND_COMMITS)?;
+
     // rev-list is newest first; a trend reads oldest to newest.
     for sha in commits.iter().rev() {
-        for r in notes::read(None, sha)? {
-            if let Some(v) = r.metrics.get(compare::GATED_METRIC) {
-                trend
-                    .entry((r.bench.clone(), r.tool.clone(), r.runner.clone()))
-                    .or_default()
-                    .push(*v);
-            }
+        // Skip the head if the walk already covers it — otherwise its value is
+        // plotted twice and the line ends in a flat step that never happened.
+        if sha == head_sha {
+            continue;
         }
+        add_point(&mut trend, &notes::read(None, sha)?);
     }
-    for r in head_records {
-        if let Some(v) = r.metrics.get(compare::GATED_METRIC) {
-            trend
-                .entry((r.bench.clone(), r.tool.clone(), r.runner.clone()))
-                .or_default()
-                .push(*v);
-        }
-    }
+    add_point(&mut trend, head_records);
     Ok(trend)
+}
+
+/// Append one point per series from a single commit's records.
+///
+/// The minimum, matching how `compare` folds duplicates. A commit can carry
+/// several records for one series — a CI re-run, a retry — and taking each of
+/// them as its own point let a noisy re-run put a spike in the trend that the
+/// table, which reduces to the minimum, does not show.
+fn add_point(trend: &mut compare::Trend, records: &[Record]) {
+    let mut lowest: BTreeMap<(String, String, String), f64> = BTreeMap::new();
+    for r in records {
+        if let Some(v) = r.metrics.get(compare::GATED_METRIC) {
+            let key = (r.bench.clone(), r.tool.clone(), r.runner.clone());
+            lowest
+                .entry(key)
+                .and_modify(|e| {
+                    if v < e {
+                        *e = *v;
+                    }
+                })
+                .or_insert(*v);
+        }
+    }
+    for (key, value) in lowest {
+        trend.entry(key).or_default().push(value);
+    }
 }
 
 /// Compare `rev` against `base`, print the report, and gate on it.
@@ -437,7 +455,7 @@ fn cmd_compare(
     let comparison = compare::compare(&base_records, &head_records);
     // Never fatal: a shallow checkout has no history to walk, and a missing
     // sparkline is a smaller loss than a failed gate.
-    let trend = gather_trend(&base_sha, &head_records).unwrap_or_default();
+    let trend = gather_trend(&base_sha, &head_sha, &head_records).unwrap_or_default();
     print!(
         "{}",
         compare::markdown(&comparison, &trend, settings.gate_pct, settings.credit)


### PR DESCRIPTION
**Two review findings from #22 that never reached main.** I pushed them to that branch after it had already merged, so both shipped in v0.0.4. Same trap as #18 → #20, and I should have checked the merge state before pushing rather than after.

## Trend ignored the minimum fold

`gather_trend` pushed every record's value while `compare` folds duplicates to the minimum. A commit carrying several records for one series — a CI re-run, a retry — contributed several points, so a noisy re-run put a spike in the sparkline that the table beside it did not show. **The two halves of one report disagreeing** is worse than either being wrong alone, because there is no way for a reader to tell which to believe.

It now takes the minimum per commit, the same rule `compare` uses, and skips the head commit when the history walk already covers it rather than plotting its value twice and ending the line in a flat step that never happened.

## Tool identity dropped from added/removed

Two series differing only by tool rendered identically, so a report could say the same benchmark both started *and* stopped gating while meaning two different programs. Both lists now go through one `describe`, matching how the table already names a series, with a test that a `self` and a `pnpm` series on the same runner render distinctly.

## Worth noting

Every finding on #22 was in the rendering layer, not the comparison. The `Comparison` struct has been correct throughout; the reports built from it were wrong three times. That is an argument for the layer existing and a sharper one for testing rendered output rather than the struct behind it — which is precisely the hole my own tests had.

90 tests, clippy `-D warnings` and fmt clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to trend assembly and markdown outlier formatting; gating still uses the existing `compare` logic, with new unit tests on rendered behavior.
> 
> **Overview**
> Fixes **compare report rendering** so sparklines and outlier lists match what the comparison table already shows.
> 
> **Trend / sparklines:** `gather_trend` now delegates to `compare::build_trend`, which emits **one instruction point per commit** by taking the **minimum** across duplicate records on that commit (same rule as `compare`). It also places the head revision **in chronological order** when that SHA already appears in the walked history (e.g. comparing against an ancestor), instead of always appending head values at the end.
> 
> **Added/removed prose:** New `describe` helper names series with **bench, runner, and tool** (tool omitted only for `self`), so two series that differ only by tool no longer look identical in the “new” / “stopped gating” lines.
> 
> Tests cover tool disambiguation, branch vs in-history head placement, and per-commit minimum folding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9233b41e6d3901e806fd5267dd39048c7ab79f68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->