### PR TITLE
fix: use theme-aware transparent docs logos

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -60,7 +60,11 @@ export default defineConfig({
   ],
 
   themeConfig: {
-    logo: "/favicon.svg",
+    logo: {
+      light: "/logo-light.svg",
+      dark: "/logo-dark.svg",
+      alt: "tak logo",
+    },
 
     nav: [
       { text: "The experiment", link: "/guide/experiment" },

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,8 @@ hero:
   text: A tachometer for code
   tagline: A half-baked experiment in measuring CLI work with retired instruction counts.
   image:
-    src: /favicon.svg
+    light: /logo-light.svg
+    dark: /logo-dark.svg
     alt: tak logo
   actions:
     - theme: brand

--- a/docs/public/logo-dark.svg
+++ b/docs/public/logo-dark.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="16 16 224 224" role="img" aria-label="tak">
+  <g transform="translate(128,128) scale(0.88) translate(-128,-128)">
+    <path d="M 38.37 205.75 A 103.5 103.5 0 1 1 217.63 205.75" stroke="#566173" fill="none" stroke-width="18" stroke-linecap="round"/>
+    <path d="M 223.96 115.23 A 103.5 103.5 0 0 1 217.63 205.75" stroke="#E5484D" fill="none" stroke-width="18" stroke-linecap="round"/>
+    <path d="M 38.37 205.75 A 103.5 103.5 0 0 1 202.45 82.1" stroke="#F0A02A" fill="none" stroke-width="18" stroke-linecap="round"/>
+    <path d="M 186.63 97.39 L 138.42 164.79 L 117.58 143.21 Z" fill="#F2F5F9"/>
+    <circle cx="128" cy="154" r="22" fill="#F2F5F9"/>
+    <circle cx="128" cy="154" r="8.5" fill="#F0A02A"/>
+  </g>
+</svg>

--- a/docs/public/logo-light.svg
+++ b/docs/public/logo-light.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="16 16 224 224" role="img" aria-label="tak">
+  <g transform="translate(128,128) scale(0.88) translate(-128,-128)">
+    <path d="M 38.37 205.75 A 103.5 103.5 0 1 1 217.63 205.75" stroke="#687386" fill="none" stroke-width="18" stroke-linecap="round"/>
+    <path d="M 223.96 115.23 A 103.5 103.5 0 0 1 217.63 205.75" stroke="#E5484D" fill="none" stroke-width="18" stroke-linecap="round"/>
+    <path d="M 38.37 205.75 A 103.5 103.5 0 0 1 202.45 82.1" stroke="#F0A02A" fill="none" stroke-width="18" stroke-linecap="round"/>
+    <path d="M 186.63 97.39 L 138.42 164.79 L 117.58 143.21 Z" fill="#0F131A"/>
+    <circle cx="128" cy="154" r="22" fill="#0F131A"/>
+    <circle cx="128" cy="154" r="8.5" fill="#F0A02A"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

- add transparent light- and dark-mode gauge assets
- use the theme-aware assets in the homepage hero and navbar
- keep the opaque square artwork only for favicons, where that treatment fits

## Why

The favicon SVG included an opaque near-black background. Reusing it as a large page logo made the artwork look like a pasted tile in both themes, and its light needle did not work cleanly against a transparent light background.

The new light variant uses a dark needle, while the dark variant keeps the light needle. Both preserve the existing gauge and remove the surrounding tile.

## Validation

- `mise run docs:check`
- rendered and visually checked the homepage in forced light and dark color schemes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only asset and VitePress config changes with no runtime or security impact.
> 
> **Overview**
> **Docs branding** no longer reuses the opaque `favicon.svg` for large in-page logos. New transparent **`logo-light.svg`** and **`logo-dark.svg`** gauge assets replace it on the **homepage hero** and **navbar**, with light/dark needle colors suited to each theme.
> 
> VitePress **`themeConfig.logo`** and the home layout **`hero.image`** now point at those paired assets instead of a single `src`. **Favicon / PWA icon links** still use the existing square artwork.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e52cd35958146b84c2e52f7b592a0f27409cb2d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->