### PR TITLE
ci: run perf jobs on bamboo

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - bamboo-perf

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -57,8 +57,8 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-
+      # Compile inside this disposable VM. Restoring target/ can relabel a
+      # binary built on a different runner class as a Bamboo measurement.
       - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           cache: false

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -27,7 +27,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
-  TAK_RUNNER: bamboo-v1-ubuntu24.04-x64-rust1.97.1
+  TAK_RUNNER: bamboo-v2-ubuntu24.04-x64-30vcpu-24gb-rust1.97.1
 
 jobs:
   measure:

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -32,6 +32,7 @@ env:
 jobs:
   measure:
     name: Compare instruction counts
+    if: github.event.pull_request.user.login == 'jdx'
     # Same runner class as perf.yml and perf-backfill.yml. Absolute counts shift
     # between machine types by more than a real regression does, so a comparison
     # across runner classes is not a comparison — tak refuses to make one, and
@@ -138,7 +139,7 @@ jobs:
   report:
     name: Report and gate
     needs: measure
-    if: always()
+    if: always() && github.event.pull_request.user.login == 'jdx'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -1,0 +1,204 @@
+name: perf-pr
+
+# Measures this pull request and compares it against the commit it branched
+# from, then says so in a comment and fails if an instruction count rose beyond
+# the gate.
+#
+# The gate is the point. A chart on a dashboard is something nobody opens; a
+# failing check on the pull request that caused the regression is read by the
+# person who can still do something about it.
+#
+# Nothing here writes to refs/notes/tak. A pull request's measurements are
+# recorded locally, used for the comparison, and discarded with the runner. Only
+# main contributes to the history — a branch's numbers are not the trunk's, and
+# a series that mixes them cannot be read.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  TAK_RUNNER: bamboo-v1-ubuntu24.04-x64-rust1.97.1
+
+jobs:
+  measure:
+    name: Compare instruction counts
+    # Same runner class as perf.yml and perf-backfill.yml. Absolute counts shift
+    # between machine types by more than a real regression does, so a comparison
+    # across runner classes is not a comparison — tak refuses to make one, and
+    # the report would say "nothing was compared" instead of anything useful.
+    runs-on: bamboo-perf
+    timeout-minutes: 40
+    permissions:
+      # Read only. This job builds and runs code from the pull request, so it
+      # must not hold a token that can write anything — see the `report` job.
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The branch commit, not the merge commit actions/checkout defaults to
+          # for a pull_request event. That default is synthetic: it exists only
+          # for the run, changes whenever main advances, and measuring it would
+          # attribute a number to a commit nobody can check out. It would also
+          # make the footer below name a commit the measurement is not of.
+          ref: ${{ github.event.pull_request.head.sha }}
+          # Needed twice over: to find the merge base, and for the sparkline,
+          # which walks twenty commits of trunk history.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+        with:
+          cache: false
+        env:
+          MISE_LOCKED: "1"
+
+      - name: Install valgrind
+        run: |
+          command -v valgrind || {
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends valgrind
+          }
+          valgrind --version
+
+      # `--record` writes a git note locally and nothing more. There is no
+      # `tak push` in this workflow and there should never be one.
+      - name: Measure this pull request
+        run: mise run perf:record
+
+      - name: Find the base commit
+        id: base
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          git fetch --quiet origin "$BASE_REF"
+          # The merge base, not the branch tip: comparing against a moving
+          # target attributes other people's commits to this pull request.
+          base=$(git merge-base "origin/$BASE_REF" HEAD)
+          echo "sha=$base" >> "$GITHUB_OUTPUT"
+          echo "comparing against $base on $BASE_REF"
+
+      # Deliberately not `continue-on-error`. That would hide a compare that
+      # died for an unrelated reason behind a green check. The exit code is
+      # captured, the comment is posted either way, and a later step re-raises
+      # it — so a regression always arrives with the table that explains it.
+      - name: Compare against the base
+        env:
+          BASE_SHA: ${{ steps.base.outputs.sha }}
+        run: |
+          set +e
+          tak compare "$BASE_SHA" > /tmp/tak-report.md
+          echo $? > /tmp/tak-gate-status
+          set -e
+          cat /tmp/tak-report.md
+          cat /tmp/tak-report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Package the report
+        if: always()
+        env:
+          BASE_SHA: ${{ steps.base.outputs.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          mkdir -p /tmp/tak-out
+          # A missing report means an earlier step died. Say so, rather than
+          # letting the reporting job find nothing and infer a pass.
+          if [ -f /tmp/tak-report.md ]; then
+            cp /tmp/tak-report.md /tmp/tak-out/report.md
+          else
+            echo "The comparison never ran — an earlier step failed." > /tmp/tak-out/report.md
+          fi
+          # 2, not 1: a missing status means the comparison never ran, which is
+          # a different failure from a regression and must not be reported as
+          # one. The gate below maps them to different messages.
+          cp /tmp/tak-gate-status /tmp/tak-out/status 2>/dev/null || echo 2 > /tmp/tak-out/status
+          printf '%s %s\n' "${HEAD_SHA:0:12}" "${BASE_SHA:0:12}" > /tmp/tak-out/shas
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: always()
+        with:
+          name: tak-report
+          path: /tmp/tak-out
+          retention-days: 1
+          if-no-files-found: error
+
+  # A separate job so the write token is never in scope while code from the
+  # pull request is executing. This one checks out nothing and runs no project
+  # code: it reads an artifact and talks to the API.
+  report:
+    name: Report and gate
+    needs: measure
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      pull-requests: write # the sticky comment, and nothing else
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: tak-report
+          path: /tmp/tak-out
+
+      # Skipped for pull requests from forks, which get a read-only token. The
+      # comparison and the gate still run there; only the comment is missing.
+      - name: Comment on the pull request
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_tak: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          marker='<!-- tak-perf-pr -->'
+          read -r head_sha base_sha < /tmp/tak-out/shas
+          # The backticks below are markdown, not command substitution, and
+          # single quotes are what keeps them literal.
+          # shellcheck disable=SC2016
+          {
+            printf '%s\n' "$marker"
+            printf '### Instruction counts\n\n'
+            cat /tmp/tak-out/report.md
+            printf '\n<sub>`%s` vs `%s` · measured on the runner, not pushed to the history.</sub>\n' \
+              "$head_sha" "$base_sha"
+          } > /tmp/tak-comment.md
+
+          # One comment per pull request, edited in place. A new comment on
+          # every push buries the conversation under numbers.
+          existing="$(gh api "repos/$GH_tak/issues/$PR_NUMBER/comments" --paginate \
+            --jq ".[] | select(.body | contains(\"$marker\")) | .id" | tail -n1)"
+          if [ -n "$existing" ]; then
+            gh api --method PATCH "repos/$GH_tak/issues/comments/$existing" \
+              --field body="$(cat /tmp/tak-comment.md)"
+          else
+            gh api --method POST "repos/$GH_tak/issues/$PR_NUMBER/comments" \
+              --field body="$(cat /tmp/tak-comment.md)"
+          fi
+
+      # `always()` on both this step and the job: a failed step stops the ones
+      # after it, and the gate is the reason this workflow exists. Without it a
+      # `gh api` hiccup would skip the gate — red for the wrong reason, and with
+      # no regression error to read.
+      - name: Fail on a regression
+        if: always()
+        run: |
+          status=$(cat /tmp/tak-out/status)
+          case "$status" in
+            0) ;;
+            2)
+              echo "::error::the comparison never ran — an earlier step failed, so nothing was gated"
+              exit 1
+              ;;
+            *)
+              echo "::error::an instruction count rose beyond the gate — see the comment or the job summary"
+              exit "$status"
+              ;;
+          esac

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -99,7 +99,7 @@ jobs:
           BASE_SHA: ${{ steps.base.outputs.sha }}
         run: |
           set +e
-          tak compare "$BASE_SHA" > /tmp/tak-report.md
+          ./target/release/tak compare "$BASE_SHA" > /tmp/tak-report.md
           echo $? > /tmp/tak-gate-status
           set -e
           cat /tmp/tak-report.md

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -44,8 +44,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-
+      # Compile inside this disposable VM. Restoring target/ can relabel a
+      # binary built on a different runner class as a Bamboo measurement.
       - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           cache: false

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -27,7 +27,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
-  TAK_RUNNER: bamboo-v1-ubuntu24.04-x64-rust1.97.1
+  TAK_RUNNER: bamboo-v2-ubuntu24.04-x64-30vcpu-24gb-rust1.97.1
 
 jobs:
   measure:

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -84,7 +84,7 @@ jobs:
           REPOSITORY: ${{ github.repository }}
         run: |
           git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY}.git"
-          tak push
+          ./target/release/tak push
 
       - name: Summary
-        run: tak history >> "$GITHUB_STEP_SUMMARY"
+        run: ./target/release/tak history >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,0 +1,90 @@
+name: perf
+
+# Records tak's startup cost for every commit that lands on main, into the
+# git-notes ref `refs/notes/tak`. The data lives in this repository — there is
+# no external service holding it, and `git fetch origin refs/notes/tak:refs/notes/tak`
+# gets you the whole history.
+#
+# Only runs post-merge. A PR-time gate is the eventual goal, but a gate needs a
+# baseline series to compare against, and right now there is none. This builds
+# that baseline.
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions: {}
+
+# Never two at once. Concurrent runs race the notes push; tak retries with a
+# cat_sort_uniq merge so nothing is lost, but serialising avoids the churn.
+# cancel-in-progress is off deliberately: every commit gets a measurement, and
+# a cancelled run is a hole in the series.
+concurrency:
+  group: perf
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  TAK_RUNNER: bamboo-v1-ubuntu24.04-x64-rust1.97.1
+
+jobs:
+  measure:
+    name: Measure
+    # Pinned to one runner class on purpose. Absolute instruction counts shift
+    # between machine types by more than a real regression does, so a series
+    # that wanders between runners is unreadable.
+    runs-on: bamboo-perf
+    timeout-minutes: 30
+    permissions:
+      contents: write # pushing refs/notes/tak is a write to this repository
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+        with:
+          cache: false
+        env:
+          MISE_LOCKED: "1"
+
+      # cachegrind is the whole point: it counts instructions, which reproduce
+      # to ~0.02% run-to-run where wall clock on this same hardware moves by
+      # 4-20%. Without it tak still records timing, but the series stops being
+      # precise enough to detect anything.
+      - name: Install valgrind
+        run: |
+          command -v valgrind || {
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends valgrind
+          }
+          valgrind --version
+
+      - name: Measure and record
+        run: mise run perf:record
+
+      # persist-credentials: false means the push needs its own auth. Same
+      # pattern as bench-refresh.yml: re-point origin rather than pushing to a
+      # one-shot URL, so tak's retry path has a remote to fetch from when it
+      # loses a race.
+      #
+      # Only main publishes. workflow_dispatch can be pointed at any branch or
+      # tag, and refs/notes/tak is a shared baseline that should hold main's
+      # history and nothing else. Gating the push rather than the whole job
+      # means a dispatch on a branch still measures and still prints its
+      # numbers in the summary — it just keeps them local.
+      - name: Push measurements
+        if: github.ref == 'refs/heads/main'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY}.git"
+          tak push
+
+      - name: Summary
+        run: tak history >> "$GITHUB_STEP_SUMMARY"

--- a/mise.toml
+++ b/mise.toml
@@ -15,6 +15,19 @@ usage = "latest"
 description = "Build the debug binary"
 run = "cargo build"
 
+# Instruction-counted benchmarks (see tak.toml). The just-built release binary
+# is the measuring instrument, so this exercises the same source revision as
+# the benchmark subject without relying on a separately installed tak.
+[tasks.perf]
+description = "Build release mode and run the performance benchmarks"
+run = ["cargo build --release", "./target/release/tak run"]
+
+# Same measurement, appended to refs/notes/tak for this commit. Nothing leaves
+# the machine until `tak push`; the perf workflows are the publisher.
+[tasks."perf:record"]
+description = "Record the performance benchmarks in git notes"
+run = ["cargo build --release", "./target/release/tak run --record"]
+
 [tasks.test]
 description = "Run the test suite, including the cachegrind integration tests"
 # --all-targets so tests/counters.rs is included. Without valgrind installed it


### PR DESCRIPTION
## Summary

- add `perf` and `perf:record` mise tasks for Tak itself
- add main and pull-request performance workflows on the isolated `bamboo-perf` runner
- keep pull-request reporting on a GitHub-hosted runner with a separate write token

## Validation

- `actionlint` (with `bamboo-perf` registered as the expected custom label)
- `mise tasks ls`
- `git diff --check`
- trusted `main` baseline queued on the disposable runner

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces self-hosted CI that writes git notes on main and executes PR-supplied code on bamboo-perf, though PR measure jobs are read-only and commenting is isolated on GitHub-hosted runners.
> 
> **Overview**
> Adds **instruction-count performance CI** on the dedicated `bamboo-perf` runner, with `mise` tasks **`perf`** and **`perf:record`** (release build + `tak run` / `tak run --record`).
> 
> **`perf` on `main`** measures each merge (and optional `workflow_dispatch`), records via `perf:record`, and **pushes** results to `refs/notes/tak` only on `main`. Builds run without `target/` cache and install valgrind so counts stay comparable on one runner class (`TAK_RUNNER` pinned).
> 
> **`perf-pr`** compares the PR head (not the merge commit) against the **merge-base** with `tak compare`, **fails the check** on regressions, and posts/updates a sticky PR comment from a separate **`report`** job on `ubuntu-latest` so PR code never runs with write tokens. PR measurements stay local (no notes push). Workflows are currently gated to PRs from user `jdx`; actionlint registers the `bamboo-perf` label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e13307ce8797919698e40d9f1834cec851a87b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated performance checks for pull requests and pushes to the main branch, with optional manual runs.
  * Performance results are compared against the merge-base commit to detect regressions and summarized in workflow reports.
  * Added commands for running benchmarks and recording results for historical tracking.
  * Reports are uploaded for review and may be posted to pull requests automatically.
  * Performance runs now use a consistent, dedicated execution environment for more reliable comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->