### PR TITLE
docs: replace experiment framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 > [hyperfine](https://github.com/sharkdp/hyperfine). If you need CI benchmark tracking, use
 > [Bencher](https://bencher.dev) or [CodSpeed](https://codspeed.io).
 
-## The experiment
+## Why instruction counts
 
 Wall-clock time on a shared CI runner has roughly the same noise floor as the regressions
 people want to catch. tak asks whether retired instruction counts can provide a deterministic
@@ -38,8 +38,8 @@ enough for a tight threshold.
 Measurements stay in the repository as JSON lines under `refs/notes/tak`, merged with git's
 `cat_sort_uniq` strategy. There is no database, account, or hosted service.
 
-Read [the full experiment](https://tak.jdx.dev/guide/experiment) for the measurements,
-limitations, and reasoning.
+Read [the methodology](https://tak.jdx.dev/guide/methodology) for the measurements, limitations,
+and reasoning.
 
 ## What exists
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -31,7 +31,7 @@ const latestVersion = versionMatch?.[1] ?? "0.0.0";
 
 export default defineConfig({
   title: "tak",
-  description: "Pre-v1 deterministic CLI benchmarking with instruction counts",
+  description: "Deterministic CLI benchmarking with instruction counts",
   cleanUrls: true,
   lastUpdated: true,
 
@@ -46,7 +46,7 @@ export default defineConfig({
       "meta",
       {
         property: "og:description",
-        content: "Pre-v1 deterministic CLI benchmarking with instruction counts",
+        content: "Deterministic CLI benchmarking with instruction counts",
       },
     ],
     [

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -31,7 +31,7 @@ const latestVersion = versionMatch?.[1] ?? "0.0.0";
 
 export default defineConfig({
   title: "tak",
-  description: "A half-baked experiment in deterministic CLI benchmarking",
+  description: "Pre-v1 deterministic CLI benchmarking with instruction counts",
   cleanUrls: true,
   lastUpdated: true,
 
@@ -46,7 +46,7 @@ export default defineConfig({
       "meta",
       {
         property: "og:description",
-        content: "A half-baked experiment in deterministic CLI benchmarking",
+        content: "Pre-v1 deterministic CLI benchmarking with instruction counts",
       },
     ],
     [
@@ -67,7 +67,7 @@ export default defineConfig({
     },
 
     nav: [
-      { text: "The experiment", link: "/guide/experiment" },
+      { text: "Methodology", link: "/guide/methodology" },
       { text: "Getting started", link: "/guide/getting-started" },
       { text: "CLI reference", link: "/cli/" },
       {
@@ -80,7 +80,7 @@ export default defineConfig({
       {
         text: "Guide",
         items: [
-          { text: "The experiment", link: "/guide/experiment" },
+          { text: "Methodology", link: "/guide/methodology" },
           { text: "Getting started", link: "/guide/getting-started" },
           { text: "Adopt tak in a project", link: "/guide/adopting" },
           { text: "Benchmark configuration", link: "/guide/configuration" },

--- a/docs/guide/methodology.md
+++ b/docs/guide/methodology.md
@@ -1,4 +1,4 @@
-# The experiment
+# Methodology
 
 ::: warning Pre-v1 software
 tak is pre-v1. Its interfaces and behavior are not finalized and may change incompatibly

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,8 +11,8 @@ hero:
     alt: tak logo
   actions:
     - theme: brand
-      text: Read the experiment
-      link: /guide/experiment
+      text: Read the methodology
+      link: /guide/methodology
     - theme: alt
       text: CLI reference
       link: /cli/
@@ -20,10 +20,10 @@ hero:
 features:
   - title: Deterministic first
     details: Instruction counts vary by roughly 0.02% between runs, making small regressions visible where wall time cannot.
-    link: /guide/experiment
+    link: /guide/methodology
   - title: Timing is context, not a gate
     details: Wall-clock measurements are recorded, but contention makes them too noisy for a tight CI threshold.
-    link: /guide/experiment#two-tiers-of-metrics
+    link: /guide/methodology#two-tiers-of-metrics
   - title: History stays in git
     details: Measurements are JSON lines in refs/notes/tak, with no database, account, or hosted service.
     link: /guide/ci


### PR DESCRIPTION
## Summary

- rename the methodology guide and route
- replace “the experiment” wording across the README and documentation
- update site metadata to describe tak as pre-v1 deterministic CLI benchmarking

This removes the old experimental framing now that it no longer matches how tak should describe itself. Existing `/guide/experiment` links are intentionally not preserved.

## Validation

- `npm run docs:build`
- verified the repository contains no remaining uses of `experiment`

AI-generated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and routing copy only; no runtime or benchmark logic changes, with intentional breakage of old `/guide/experiment` links.
> 
> **Overview**
> Reframes tak’s public docs from an **experimental** narrative to a **methodology**-focused one, without changing product behavior.
> 
> The guide at `/guide/experiment` is renamed to **Methodology** at `/guide/methodology` (old URL is not redirected). README, VitePress nav/sidebar, and the docs home page now point to that route and use a **“Why instruction counts”** section title instead of **“The experiment.”** Site and Open Graph descriptions drop “half-baked experiment” in favor of **deterministic CLI benchmarking with instruction counts.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4aac0eadd7812fe101cd617b107e5085e03faa8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->