### PR TITLE
chore: manage usage cli with mise

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -68,3 +68,37 @@ url = "https://nodejs.org/dist/v24.19.0/node-v24.19.0-darwin-arm64.tar.gz"
 [tools.node."platforms.windows-x64"]
 checksum = "sha256:57f71ab3652e797d84acddc79c81cc9ff1c6ddb2a1974cdb83f00fee9bff4c73"
 url = "https://nodejs.org/dist/v24.19.0/node-v24.19.0-win-x64.zip"
+
+[[tools.usage]]
+version = "6.1.0"
+backend = "aqua:jdx/usage"
+
+[tools.usage."platforms.linux-arm64"]
+checksum = "sha256:bb52c86367cabd59d455debdc8402434a7863cc5d24b506e9230409a187ceb57"
+url = "https://github.com/jdx/usage/releases/download/v6.1.0/usage-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/525532817"
+
+[tools.usage."platforms.linux-arm64-musl"]
+checksum = "sha256:bb52c86367cabd59d455debdc8402434a7863cc5d24b506e9230409a187ceb57"
+url = "https://github.com/jdx/usage/releases/download/v6.1.0/usage-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/525532817"
+
+[tools.usage."platforms.linux-x64"]
+checksum = "sha256:2ceec78d071d66a5dcdcc6ad68a5ee79c64fc6c2fbe0050d4f013dfbc3308ba2"
+url = "https://github.com/jdx/usage/releases/download/v6.1.0/usage-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/525532821"
+
+[tools.usage."platforms.linux-x64-musl"]
+checksum = "sha256:2ceec78d071d66a5dcdcc6ad68a5ee79c64fc6c2fbe0050d4f013dfbc3308ba2"
+url = "https://github.com/jdx/usage/releases/download/v6.1.0/usage-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/525532821"
+
+[tools.usage."platforms.macos-arm64"]
+checksum = "sha256:317156bbd740ce95195e1016eb6800145944b4dbd2bd7e4f874684761b989524"
+url = "https://github.com/jdx/usage/releases/download/v6.1.0/usage-universal-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/525531450"
+
+[tools.usage."platforms.windows-x64"]
+checksum = "sha256:816843e71bf5ecc2d458b328b89edc771ca0a1f8b1777ff7be254007920a64bf"
+url = "https://github.com/jdx/usage/releases/download/v6.1.0/usage-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/525535418"

--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,5 @@
 [tools]
+usage = "6.1.0"
 # communique rewrites release bodies and Node builds the docs. Rust-only CI jobs
 # run mise-action with `install: false` and
 # dedicated jobs install only what they need. Rust itself comes from
@@ -72,20 +73,14 @@ depends = ["render:check"]
 dir = "docs"
 run = "npm ci && exec npm run docs:build"
 
-[tasks."build:usage"]
-description = "Build the usage 6 CLI revision that matches usage-rs"
-sources = ["Cargo.lock", "Cargo.toml", "mise.toml"]
-outputs = ["target/usage-cli/bin/usage"]
-run = "cargo install --force --version 6.1.0 usage-cli --root target/usage-cli --locked"
-
 [tasks.render]
 description = "Regenerate the CLI reference from usage metadata"
-depends = ["build", "build:usage"]
+depends = ["build"]
 run = [
     "./target/debug/tak usage > tak.usage.kdl",
     "rm -rf docs/cli && mkdir -p docs/cli",
-    "./target/usage-cli/bin/usage generate markdown --multi -f tak.usage.kdl --out-dir docs/cli --url-prefix /cli",
-    "./target/usage-cli/bin/usage generate json -f tak.usage.kdl > docs/cli/commands.json",
+    "usage generate markdown --multi -f tak.usage.kdl --out-dir docs/cli --url-prefix /cli",
+    "usage generate json -f tak.usage.kdl > docs/cli/commands.json",
 ]
 
 [tasks."render:check"]


### PR DESCRIPTION
## Summary

- pin the precompiled usage 6.1.0 release in mise.toml and mise.lock
- use the mise-managed usage executable during docs rendering
- remove the custom cargo install task and target-local binary path

## Verification

- MISE_LOCKED=1 mise install usage@6.1.0
- usage --version
- mise run render:check
- mise run ci

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*