### PR TITLE
chore(deps): bump usage to 6.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,21 +227,21 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "usage-argv"
-version = "6.2.0"
+version = "6.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "857c0a155957d220665b2257ac7c58e168476ff7de09286940055ff78f622fb0"
+checksum = "832f849be4b8046c843219bc92d067a6689530df53f56e3c0a52ff5ebbd2f89b"
 
 [[package]]
 name = "usage-config"
-version = "6.2.0"
+version = "6.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a03db6df00ecda2b8fbdd6819bb1f6d0ea82d593d0620e6030eb11e0c9aa3c"
+checksum = "26de7cdb0937b87c778ae50e733a6922eaf9994d79eede89af62e09edf7dbd9f"
 
 [[package]]
 name = "usage-derive"
-version = "6.2.0"
+version = "6.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9b6be9a69c5659c8002ac46be4262fd6e3ef57db53787df0f85b2d116c9e790"
+checksum = "5634bb965ae075c5cedfc27942f7e6110bf5e7e169cba04de86346f4aeee41e7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -250,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "usage-rs"
-version = "6.2.0"
+version = "6.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "689ff9bfcf0c894d94a44171b27f6533db7d44a9615b17cef9b846590df13463"
+checksum = "12a8c2b63902582429527f21cd91d2da0065fb9222b8a2a5b87d8f77c7daf71e"
 dependencies = [
  "usage-argv",
  "usage-config",

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -715,7 +715,7 @@
     "flags": [
       {
         "name": "env-deny",
-        "usage": "--env-deny… <VAR>",
+        "usage": "--env-deny <VAR>",
         "help": "Remove a variable from the environment of measured commands. Repeatable. Replaces the default list rather than adding to it.",
         "help_first_line": "Remove a variable from the environment of measured commands. Repeatable. Replaces the default list rather than adding to it.",
         "short": [],
@@ -735,7 +735,7 @@
       },
       {
         "name": "env-allow",
-        "usage": "--env-allow… <VAR>",
+        "usage": "--env-allow <VAR>",
         "help": "Keep a variable that --env-deny would remove. Repeatable.",
         "help_first_line": "Keep a variable that --env-deny would remove. Repeatable.",
         "short": [],

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -6,8 +6,8 @@
 - **Usage:** `tak [FLAGS] <SUBCOMMAND>`
 
 ## Global Flags
-- **`--env-deny… <VAR>`** — Remove a variable from the environment of measured commands. Repeatable. Replaces the default list rather than adding to it.
-- **`--env-allow… <VAR>`** — Keep a variable that --env-deny would remove. Repeatable.
+- **`--env-deny <VAR>`** — Remove a variable from the environment of measured commands. Repeatable. Replaces the default list rather than adding to it.
+- **`--env-allow <VAR>`** — Keep a variable that --env-deny would remove. Repeatable.
 - **`--gate-pct <PCT>`** — Percentage an instruction count may rise before `compare` fails.
 - **`--no-credit`** — Leave the line naming tak off the end of generated reports.
 

--- a/mise.lock
+++ b/mise.lock
@@ -70,35 +70,35 @@ checksum = "sha256:57f71ab3652e797d84acddc79c81cc9ff1c6ddb2a1974cdb83f00fee9bff4
 url = "https://nodejs.org/dist/v24.19.0/node-v24.19.0-win-x64.zip"
 
 [[tools.usage]]
-version = "6.2.0"
+version = "6.4.0"
 backend = "aqua:jdx/usage"
 
 [tools.usage."platforms.linux-arm64"]
-checksum = "sha256:93502e6ec4c4efe5437a8ef0970b0d87cd88020e341bcdd6b0b78022ce316a4b"
-url = "https://github.com/jdx/usage/releases/download/v6.2.0/usage-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/usage/releases/assets/527050809"
+checksum = "sha256:96acfe9a312da8af144dd516b9347bd7de62391ca797dba722aed48abe5ec21d"
+url = "https://github.com/jdx/usage/releases/download/v6.4.0/usage-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/528035595"
 
 [tools.usage."platforms.linux-arm64-musl"]
-checksum = "sha256:86d8273aee09adc471ac34e8e61ef8386fc26b2d06cc43985722b705a52c5a7e"
-url = "https://github.com/jdx/usage/releases/download/v6.2.0/usage-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/usage/releases/assets/527051257"
+checksum = "sha256:60ff89e6d87cabcbc6c20fc851911c78490c605d38553147a62e1dce30e6470a"
+url = "https://github.com/jdx/usage/releases/download/v6.4.0/usage-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/528035659"
 
 [tools.usage."platforms.linux-x64"]
-checksum = "sha256:38df801e9ed2b4d23ea66793a25369f52d92c4aefd55ebacb6e343a2ab84528d"
-url = "https://github.com/jdx/usage/releases/download/v6.2.0/usage-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/usage/releases/assets/527050648"
+checksum = "sha256:04007997a0524aa5934458530cd025e1745e0b0803aac74559cc03a26b66c53b"
+url = "https://github.com/jdx/usage/releases/download/v6.4.0/usage-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/528035518"
 
 [tools.usage."platforms.linux-x64-musl"]
-checksum = "sha256:ded7d1815254fe064b07a8f33251b8e112ec346c338e476ce0e9ee8d8babc0ed"
-url = "https://github.com/jdx/usage/releases/download/v6.2.0/usage-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/usage/releases/assets/527051701"
+checksum = "sha256:c416e18838f974810f8b67ac1eed6ef170cf9ff48e165469563885f24c548d90"
+url = "https://github.com/jdx/usage/releases/download/v6.4.0/usage-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/528035933"
 
 [tools.usage."platforms.macos-arm64"]
-checksum = "sha256:6c2d37e3cba67d45fdfeb5edaff81962388bfde09667cc9ed35b0734b7c0a8c1"
-url = "https://github.com/jdx/usage/releases/download/v6.2.0/usage-universal-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/usage/releases/assets/527053103"
+checksum = "sha256:c02f4235446b06f917747e6bdaa6496ea3f63a66c74081a5c1450da2c734f6f1"
+url = "https://github.com/jdx/usage/releases/download/v6.4.0/usage-universal-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/528044147"
 
 [tools.usage."platforms.windows-x64"]
-checksum = "sha256:c13234e43cee2b172376ade8d0cdd1ea26c8a2032275b283243b05de57256c3f"
-url = "https://github.com/jdx/usage/releases/download/v6.2.0/usage-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/usage/releases/assets/527054199"
+checksum = "sha256:6ffa5d4deb26c6728ea9ab5d9c7b76c3c4ca75cb6bf49acdace1045512fa7cd3"
+url = "https://github.com/jdx/usage/releases/download/v6.4.0/usage-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/usage/releases/assets/528039229"

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-usage = "6.2.0"
+usage = "6.4.0"
 # communique rewrites release bodies and Node builds the docs. Rust-only CI jobs
 # run mise-action with `install: false` and
 # dedicated jobs install only what they need. Rust itself comes from


### PR DESCRIPTION
## Summary
- bump usage-rs and the standalone usage renderer to 6.4.0
- refresh Cargo.lock and mise.lock
- regenerate CLI reference artifacts with usage 6.4.0

## Validation
- cargo check --locked
- mise run test
- mise run render
- mise --locked x usage -- usage --version
- mise lock usage --dry-run --json
- git diff --check
- upstream publish-cli run completed successfully: https://github.com/jdx/usage/actions/runs/32764359979

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and lockfile updates with regenerated docs only; no tak runtime or measurement logic changes in the diff.
> 
> **Overview**
> Bumps the **usage** ecosystem from **6.2.0** to **6.4.0**: `usage-rs` and related crates in **Cargo.lock**, and the mise-managed **usage** CLI in **mise.toml** / **mise.lock**.
> 
> Regenerated CLI reference artifacts reflect usage 6.4.0’s flag formatting—global **`--env-deny`** and **`--env-allow`** now show as `--env-deny <VAR>` / `--env-allow <VAR>` instead of the previous `…` repeatable notation in **docs/cli/commands.json** and **docs/cli/index.md**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c686ad6ccdca617e2d00947a7aca40b64064feb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified CLI usage examples for repeatable `--env-deny` and `--env-allow` options with complete variable placeholders.
* **Chores**
  * Updated the CLI documentation generation tool to version 6.4.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->