### PR TITLE
chore(ci): adopt mbx for Rust builds

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -1,0 +1,13 @@
+name: Set up mbx
+description: Select the trusted jdx server or fork-safe GitHub cache backend
+
+runs:
+  using: composite
+  steps:
+    - uses: jdx/mr-boxington-action@2bbb8f141e40e388b509cc68fe0bfbe7bc4b6818 # v1
+      with:
+        version: 0.3.0
+        backend: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'github' || 'server' }}
+        server-url: https://cache.mise.jdx.dev
+        namespace: jdx/tak
+        oidc-audience: https://cache.mise.jdx.dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,11 @@ env:
 # review.
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -31,7 +34,7 @@ jobs:
         with:
           components: clippy, rustfmt
 
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      - uses: ./.github/actions/mbx
 
       # The tasks live in mise.toml so that a laptop and this runner invoke the
       # same commands — the same reason tak.toml exists for benchmarks.
@@ -54,28 +57,34 @@ jobs:
       - run: mise run test
 
   docs:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      - uses: ./.github/actions/mbx
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
       - run: mise run docs:check
 
   # macOS has no usable cachegrind, so counters are expected to be absent here.
   # This job asserts the degradation path rather than the measurement path.
   test-macos:
-    runs-on: macos-latest
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'macos-latest' || 'namespace-profile-endev-macos-arm64' }}
     timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      - uses: ./.github/actions/mbx
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           install: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,16 @@
 # tak Development Guide
 
+## mbx build cache
+
+Compilation-heavy mise tasks use `mbx`. If an mbx command fails or creates a
+development papercut, rerun the exact equivalent `cargo` command from
+`CONTRIBUTING.md`; this unblocks work without weakening the check. If Cargo
+succeeds, surface the mismatch and recommend a
+[mr-boxington Discussion](https://github.com/jdx/mr-boxington/discussions) with
+the repository and commit, OS, `mbx --version`, both commands and outputs, the
+cache summary, and `MBX_BYPASS_LOG` details when relevant. Do not silently make
+Cargo the permanent path, and do not post externally without user authorization.
+
 tak measures how much work a command does by counting instructions, and stores the results in
 the repository as git notes. Read the README before changing anything: the premise, the
 measured numbers behind it, and the pre-v1 compatibility warning are all there.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+# Contributing
+
+Use the mise tasks documented in `AGENTS.md` for development and validation.
+
+## mbx build cache
+
+The normal `mise run build`, `mise run test`, and `mise run lint` workflows use
+[mbx](https://mr-boxington.jdx.dev) for compilation-heavy Cargo work. If mbx
+appears to be the problem, use the equivalent Cargo commands to unblock
+yourself without skipping or weakening the check:
+
+```sh
+cargo build
+cargo test --all-targets
+cargo clippy --all-targets -- -D warnings
+```
+
+If Cargo succeeds where mbx fails, or mbx introduces a papercut, please start a
+[mr-boxington Discussion](https://github.com/jdx/mr-boxington/discussions).
+Include the repository and commit, operating system, `mbx --version`, both
+commands and their output, the mbx cache summary, and an `MBX_BYPASS_LOG` when
+relevant (for example, `MBX_BYPASS_LOG=mbx-bypasses.log mise run build`).

--- a/mise.lock
+++ b/mise.lock
@@ -41,6 +41,40 @@ url = "https://github.com/jdx/communique/releases/download/v1.3.2/communique-x86
 url_api = "https://api.github.com/repos/jdx/communique/releases/assets/525619633"
 provenance = "github-attestations"
 
+[[tools."github:jdx/mr-boxington"]]
+version = "0.3.0"
+backend = "github:jdx/mr-boxington"
+
+[tools."github:jdx/mr-boxington"."platforms.linux-arm64"]
+checksum = "sha256:4be02935fb0c1892b659c8146e07fe092fb12f6c4e86c6ebbc3b63449d5dcb25"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704880"
+
+[tools."github:jdx/mr-boxington"."platforms.linux-arm64-musl"]
+checksum = "sha256:4be02935fb0c1892b659c8146e07fe092fb12f6c4e86c6ebbc3b63449d5dcb25"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704880"
+
+[tools."github:jdx/mr-boxington"."platforms.linux-x64"]
+checksum = "sha256:65ef46c20761ffd1d930638c3ff2d237535a98f28968929f04f195bfdd258e77"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704890"
+
+[tools."github:jdx/mr-boxington"."platforms.linux-x64-musl"]
+checksum = "sha256:65ef46c20761ffd1d930638c3ff2d237535a98f28968929f04f195bfdd258e77"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704890"
+
+[tools."github:jdx/mr-boxington"."platforms.macos-arm64"]
+checksum = "sha256:1803cec79be0b753fc3af23044edc46fd81ffdf9d66fcb7b6637cfb22cc6db4a"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704881"
+
+[tools."github:jdx/mr-boxington"."platforms.windows-x64"]
+checksum = "sha256:9d99f1f57789e88f4870ac61fd6c4e2ceec5ed532f4c9c8e9be4f32663a1fd16"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704879"
+
 [[tools.node]]
 version = "24.19.0"
 backend = "core:node"

--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,5 @@
 [tools]
+"github:jdx/mr-boxington" = "latest"
 usage = "6.4.0"
 # communique rewrites release bodies and Node builds the docs. Rust-only CI jobs
 # run mise-action with `install: false` and
@@ -13,7 +14,7 @@ node = "24"
 
 [tasks.build]
 description = "Build the debug binary"
-run = "cargo build"
+run = "mbx build build"
 
 # Instruction-counted benchmarks (see tak.toml). The just-built release binary
 # is the measuring instrument, so this exercises the same source revision as
@@ -32,7 +33,7 @@ run = ["cargo build --release", "./target/release/tak run --record"]
 description = "Run the test suite, including the cachegrind integration tests"
 # --all-targets so tests/counters.rs is included. Without valgrind installed it
 # skips rather than fails, which is the normal state on macOS and Windows.
-run = "cargo test --all-targets"
+run = "mbx build test --all-targets"
 
 [tasks.lint]
 description = "Check formatting and run clippy"
@@ -44,7 +45,7 @@ run = "cargo fmt --check"
 
 [tasks."lint:clippy"]
 description = "Run clippy, warnings as errors"
-run = "cargo clippy --all-targets -- -D warnings"
+run = "mbx build clippy --all-targets -- -D warnings"
 
 [tasks.lint-fix]
 description = "Auto-fix formatting and the clippy lints that can be fixed"


### PR DESCRIPTION
## Summary

- route compilation-heavy local mise tasks and hk checks through mbx 0.3.0
- configure trusted Namespace jobs for the jdx server cache and fork-safe GitHub-hosted cache restores
- document exact Cargo fallbacks and the mr-boxington Discussions escalation path

## Validation

- mise lock resolution and mbx 0.3.0 execution
- canonical mbx-backed build path
- actionlint
- high-severity zizmor audit
- mise configuration and changed Pkl evaluation

Full local suites were also exercised where practical; environment-dependent checks remain delegated to CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI runner selection, OIDC permissions, and build caching for all main Rust jobs; application code is untouched, but a cache or mbx mismatch could fail builds until fallbacks are used.
> 
> **Overview**
> **CI and local Rust workflows** now use **mbx** (mr-boxington 0.3.0) instead of **Swatinem/rust-cache** for compilation-heavy Cargo work on `test`, `docs`, and `test-macos`.
> 
> A new composite action **`.github/actions/mbx`** wires **mr-boxington-action** to the jdx cache server (`cache.mise.jdx.dev`) with OIDC on trusted runs, and switches to a **GitHub-hosted cache backend** for **fork PRs** so untrusted code cannot use the shared server cache. Matching jobs gain **`id-token: write`**, and **non-fork** runs target **Namespace runner profiles** (`endev-linux-amd64` / `endev-macos-arm64`) instead of default GitHub-hosted labels.
> 
> **`mise.toml`** routes `build`, `test`, and `lint:clippy` through `mbx build`; **`mise.lock`** pins mbx. **`AGENTS.md`** and new **`CONTRIBUTING.md`** document equivalent plain **`cargo`** fallbacks and how to escalate mbx issues via mr-boxington Discussions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bf42ec54b7b201a7b48fdcf8029b7d6590988f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Build, test, and lint workflows now use a shared compilation cache to reduce repeated work and improve development and validation times.
  - Continuous integration runs with optimized environments for both fork-based contributions and trusted repository workflows.
  - macOS validation now uses the appropriate native runner configuration.

- **Documentation**
  - Added contributor guidance for common build-cache issues, fallback commands, and diagnostic information needed when reporting failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->