### PR TITLE
fix: use direct mbx command syntax

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
     - uses: jdx/mr-boxington-action@2bbb8f141e40e388b509cc68fe0bfbe7bc4b6818 # v1
       with:
-        version: 0.3.0
+        version: 0.4.0
         backend: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'github' || 'server' }}
         server-url: https://cache.mise.jdx.dev
         namespace: jdx/tak

--- a/mise.lock
+++ b/mise.lock
@@ -42,38 +42,38 @@ url_api = "https://api.github.com/repos/jdx/communique/releases/assets/525619633
 provenance = "github-attestations"
 
 [[tools."github:jdx/mr-boxington"]]
-version = "0.3.0"
+version = "0.4.0"
 backend = "github:jdx/mr-boxington"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-arm64"]
-checksum = "sha256:4be02935fb0c1892b659c8146e07fe092fb12f6c4e86c6ebbc3b63449d5dcb25"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704880"
+checksum = "sha256:ed81dab87775bcc8764c7257d8bea0dd8b7f811d6263b71bc7cd83a879661593"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719396"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-arm64-musl"]
-checksum = "sha256:4be02935fb0c1892b659c8146e07fe092fb12f6c4e86c6ebbc3b63449d5dcb25"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704880"
+checksum = "sha256:ed81dab87775bcc8764c7257d8bea0dd8b7f811d6263b71bc7cd83a879661593"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719396"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-x64"]
-checksum = "sha256:65ef46c20761ffd1d930638c3ff2d237535a98f28968929f04f195bfdd258e77"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704890"
+checksum = "sha256:b288265404b8fa4620ea1d082ba9b33a0a1695212d88a385e76aa07a743da250"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719409"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-x64-musl"]
-checksum = "sha256:65ef46c20761ffd1d930638c3ff2d237535a98f28968929f04f195bfdd258e77"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704890"
+checksum = "sha256:b288265404b8fa4620ea1d082ba9b33a0a1695212d88a385e76aa07a743da250"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719409"
 
 [tools."github:jdx/mr-boxington"."platforms.macos-arm64"]
-checksum = "sha256:1803cec79be0b753fc3af23044edc46fd81ffdf9d66fcb7b6637cfb22cc6db4a"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704881"
+checksum = "sha256:416cab92e23c4652183e4a794af3fdcbc50b56296d8c09f8b6548e7577416307"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719398"
 
 [tools."github:jdx/mr-boxington"."platforms.windows-x64"]
-checksum = "sha256:9d99f1f57789e88f4870ac61fd6c4e2ceec5ed532f4c9c8e9be4f32663a1fd16"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704879"
+checksum = "sha256:f841b1907cf86c54db4d3d2d1e88f87303ccc8f720efff90b6331d7d5592bf4e"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719397"
 
 [[tools.node]]
 version = "24.19.0"

--- a/mise.toml
+++ b/mise.toml
@@ -14,7 +14,7 @@ node = "24"
 
 [tasks.build]
 description = "Build the debug binary"
-run = "mbx build build"
+run = "mbx build"
 
 # Instruction-counted benchmarks (see tak.toml). The just-built release binary
 # is the measuring instrument, so this exercises the same source revision as
@@ -33,7 +33,7 @@ run = ["cargo build --release", "./target/release/tak run --record"]
 description = "Run the test suite, including the cachegrind integration tests"
 # --all-targets so tests/counters.rs is included. Without valgrind installed it
 # skips rather than fails, which is the normal state on macOS and Windows.
-run = "mbx build test --all-targets"
+run = "mbx test --all-targets"
 
 [tasks.lint]
 description = "Check formatting and run clippy"
@@ -45,7 +45,7 @@ run = "cargo fmt --check"
 
 [tasks."lint:clippy"]
 description = "Run clippy, warnings as errors"
-run = "mbx build clippy --all-targets -- -D warnings"
+run = "mbx clippy --all-targets -- -D warnings"
 
 [tasks.lint-fix]
 description = "Auto-fix formatting and the clippy lints that can be fixed"


### PR DESCRIPTION
## Summary

- use mr-boxington direct Cargo-subcommand syntax instead of the legacy `mbx build <subcommand>` wrapper
- update the mise lock and CI setup to the mbx 0.4.0 release that provides this syntax

## Validation

- installed the committed lock and confirmed `mbx 0.4.0`
- evaluated the mise configuration and task list
- confirmed `mbx build` direct syntax
