### PR TITLE
ci: disable caches in release workflows

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -36,8 +36,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
-
       # Exchanges the OIDC token for a short-lived crates.io token. Each crate
       # has a Trusted Publisher naming this repository and this workflow file,
       # so renaming this file breaks publishing — see RELEASING.md.
@@ -102,6 +100,8 @@ jobs:
       # depending on what `latest` means today; without this it could drift back
       # without anyone noticing.
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+        with:
+          cache: false
         env:
           MISE_LOCKED: "1"
 
@@ -156,8 +156,6 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: Run release-plz
         uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5.131

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,10 +60,6 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
-        with:
-          key: ${{ matrix.target }}
-
       # Cross-compiles and produces the archive. `dry-run` builds without
       # uploading, so a later target failing cannot leave a half-populated
       # release behind — everything is attached in one step at the end.


### PR DESCRIPTION
## Summary

- remove persistent Rust caches from release artifact and release-plz jobs
- disable mise-action caching in release workflow setup
- preserve explicit artifact upload and download handoffs

## Validation

- ran actionlint over changed workflows
- audited release and publish entrypoints for Rust, Actions, Namespace, mise, Node, and mbx caches
- confirmed all remaining cache-capable setup is explicitly disabled for release paths

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes that trade cache speed for fresher release builds; no runtime or security-sensitive application code is touched.
> 
> **Overview**
> Release CI no longer restores or saves **Rust** build caches during publish and binary jobs. **`Swatinem/rust-cache`** is removed from the `release-plz` release and release-PR jobs and from the matrix **`release.yml`** build (including the per-target cache key).
> 
> The **enhance-release** job now runs **`jdx/mise-action`** with **`cache: false`**, so communique setup stays pinned to **`mise.lock`** without reusing a cached toolchain install. Artifact upload/download between build and attach is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ce2969d7aae981c30a1ff7b1709cfd84df2b2dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->