### PR TITLE
security(ci): restrict trusted mbx runs to jdx

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -7,7 +7,7 @@ runs:
     - uses: jdx/mr-boxington-action@2bbb8f141e40e388b509cc68fe0bfbe7bc4b6818 # v1
       with:
         version: 0.4.0
-        backend: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'github' || 'server' }}
+        backend: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'github' || 'server' }}
         server-url: https://cache.mise.jdx.dev
         namespace: jdx/tak
         oidc-audience: https://cache.mise.jdx.dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ env:
 # review.
 jobs:
   test:
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 15
     permissions:
       contents: read
@@ -57,7 +57,7 @@ jobs:
       - run: mise run test
 
   docs:
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 15
     permissions:
       contents: read
@@ -74,7 +74,7 @@ jobs:
   # macOS has no usable cachegrind, so counters are expected to be absent here.
   # This job asserts the degradation path rather than the measurement path.
   test-macos:
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'macos-latest' || 'namespace-profile-endev-macos-arm64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'macos-latest' || 'namespace-profile-endev-macos-arm64' }}
     timeout-minutes: 15
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- reserve Namespace runners and the server cache for same-repository PRs authored by `jdx`
- route every other PR author, including dependency bots, through GitHub-hosted runners and GitHub cache
- keep trusted-only repository secrets unavailable to non-`jdx` PRs

## Validation

- `git diff --check`
- actionlint workflow and expression validation
- confirmed no dependency-bot-specific trust predicates remain

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*