### PR TITLE
security(ci): isolate mbx OIDC permissions

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -7,7 +7,7 @@ runs:
     - uses: jdx/mr-boxington-action@2bbb8f141e40e388b509cc68fe0bfbe7bc4b6818 # v1
       with:
         version: 0.4.0
-        backend: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'github' || 'server' }}
+        backend: ${{ (github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server' }}
         server-url: https://cache.mise.jdx.dev
         namespace: jdx/tak
         oidc-audience: https://cache.mise.jdx.dev

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -1,13 +1,18 @@
 name: Set up mbx
 description: Select the trusted jdx server or fork-safe GitHub cache backend
 
+inputs:
+  backend:
+    description: Explicit backend for structurally trusted or untrusted callers
+    default: auto
+
 runs:
   using: composite
   steps:
     - uses: jdx/mr-boxington-action@2bbb8f141e40e388b509cc68fe0bfbe7bc4b6818 # v1
       with:
         version: 0.4.0
-        backend: ${{ (github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server' }}
+        backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}
         server-url: https://cache.mise.jdx.dev
         namespace: jdx/tak
         oidc-audience: https://cache.mise.jdx.dev

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -15,7 +15,7 @@ env:
 # review.
 jobs:
   test:
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ (github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -49,7 +49,7 @@ jobs:
       - run: mise run test
 
   docs:
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ (github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -63,7 +63,7 @@ jobs:
   # macOS has no usable cachegrind, so counters are expected to be absent here.
   # This job asserts the degradation path rather than the measurement path.
   test-macos:
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'macos-latest' || 'namespace-profile-endev-macos-arm64' }}
+    runs-on: ${{ (github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'macos-latest' || 'namespace-profile-endev-macos-arm64' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -1,0 +1,135 @@
+name: ci implementation
+
+on:
+  workflow_call:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+# Actions are pinned to full commit SHAs. A mutable tag like @v2 or @stable can
+# be retargeted at any time, which would swap out executable CI code without
+# review.
+jobs:
+  test:
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          components: clippy, rustfmt
+
+      - uses: ./.github/actions/mbx
+
+      # The tasks live in mise.toml so that a laptop and this runner invoke the
+      # same commands — the same reason tak.toml exists for benchmarks.
+      # This job only runs Rust tasks. The docs and release jobs install the
+      # Node/usage and communique tools they need separately.
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+        with:
+          install: false
+
+      # The whole premise of this project is that instruction counts are stable
+      # enough to gate on. That path is a subprocess call, so it can only be
+      # exercised where valgrind exists — and it once shipped having never run.
+      # Installing it here is what keeps tests/counters.rs meaningful.
+      - name: Install valgrind
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends valgrind
+
+      - run: valgrind --version
+
+      - run: mise run lint
+      - run: mise run test
+
+  docs:
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: ./.github/actions/mbx
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+      - run: mise run docs:check
+
+  # macOS has no usable cachegrind, so counters are expected to be absent here.
+  # This job asserts the degradation path rather than the measurement path.
+  test-macos:
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'macos-latest' || 'namespace-profile-endev-macos-arm64' }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: ./.github/actions/mbx
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+        with:
+          install: false
+      - run: mise run test
+
+  # docker/Dockerfile is the documented way to get instruction counts on macOS
+  # and Windows, where there is no usable valgrind. Nothing built it, so it sat
+  # broken from the asset-picker extraction onward — the build stage never
+  # copied crates/, and cargo failed at manifest resolution. This job is the
+  # guard that keeps the documented path working.
+  docker:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # Built without a layer cache on purpose. The dependency set is small
+      # enough that a fully cold build takes about 25 seconds, which is not
+      # worth the buildx + cache-export machinery it would take to avoid.
+      - name: Build the image
+        run: docker build -f docker/Dockerfile -t tak .
+
+      - run: docker run --rm tak --version
+
+      # `tak run` degrades to wall clock when valgrind is missing instead of
+      # failing — correct for a macOS host, but it means a bare run inside the
+      # image would pass having measured nothing. The image exists solely to
+      # provide the counter, so assert the counter is in the output.
+      - name: Instruction counting works inside the image
+        run: |
+          out=$(docker run --rm tak run --bench smoke --runs 2 -- /bin/echo hi)
+          echo "$out"
+          grep -qE '^[[:space:]]*instructions[[:space:]]+[0-9]+' <<<"$out" \
+            || { echo "::error::image produced no instruction count"; exit 1; }
+
+  # Single fan-in gate, so branch protection requires one check instead of an
+  # enumerated list that goes stale every time a job is added or renamed. It
+  # also catches *skipped* jobs, which a required check would otherwise treat
+  # as passing.
+  final:
+    permissions: {}
+    needs:
+      - test
+      - test-macos
+      - docker
+      - docs
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    # Run on success or upstream failure but skip when the workflow is cancelled
+    # — `always()` would override `cancel-in-progress` and waste a runner.
+    if: ${{ !cancelled() }}
+    steps:
+      - name: Check job results
+        if: |
+          needs.test.result != 'success' ||
+          needs.test-macos.result != 'success' ||
+          needs.docker.result != 'success' ||
+          needs.docs.result != 'success'
+        run: exit 1
+      - run: echo "All CI jobs completed successfully"

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -25,6 +25,11 @@ jobs:
     runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 15
     steps:
+      - name: Assert OIDC is unavailable to untrusted CI
+        if: ${{ !inputs.trusted }}
+        run: |
+          test -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}"
+          test -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}"
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -2,6 +2,13 @@ name: ci implementation
 
 on:
   workflow_call:
+    inputs:
+      trusted:
+        required: true
+        type: boolean
+      mbx-backend:
+        required: true
+        type: string
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -15,7 +22,7 @@ env:
 # review.
 jobs:
   test:
-    runs-on: ${{ (github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -27,6 +34,8 @@ jobs:
           components: clippy, rustfmt
 
       - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.mbx-backend }}
 
       # The tasks live in mise.toml so that a laptop and this runner invoke the
       # same commands — the same reason tak.toml exists for benchmarks.
@@ -49,7 +58,7 @@ jobs:
       - run: mise run test
 
   docs:
-    runs-on: ${{ (github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -57,13 +66,15 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
       - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.mbx-backend }}
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
       - run: mise run docs:check
 
   # macOS has no usable cachegrind, so counters are expected to be absent here.
   # This job asserts the degradation path rather than the measurement path.
   test-macos:
-    runs-on: ${{ (github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'macos-latest' || 'namespace-profile-endev-macos-arm64' }}
+    runs-on: ${{ !inputs.trusted && 'macos-latest' || 'namespace-profile-endev-macos-arm64' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -71,6 +82,8 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
       - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.mbx-backend }}
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
         with:
           install: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,8 @@ permissions: {}
 
 jobs:
   trusted:
-    if: ${{ github.actor == 'jdx' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'jdx')) }}
+    # Temporary pilot probe: force this PR through the untrusted caller.
+    if: ${{ github.actor != 'jdx' }}
     permissions:
       contents: read
       id-token: write
@@ -19,7 +20,7 @@ jobs:
       mbx-backend: server
 
   untrusted:
-    if: ${{ github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx')) }}
+    if: ${{ github.actor == 'jdx' }}
     permissions:
       contents: read
     uses: ./.github/workflows/ci-impl.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,18 @@ jobs:
       contents: read
       id-token: write
     uses: ./.github/workflows/ci-impl.yml
+    with:
+      trusted: true
+      mbx-backend: server
 
   untrusted:
     if: ${{ github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx')) }}
     permissions:
       contents: read
     uses: ./.github/workflows/ci-impl.yml
+    with:
+      trusted: false
+      mbx-backend: github
 
   final:
     name: final

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
   final:
     name: final
-    if: ${{ always() && !cancelled() }}
+    if: ${{ always() && !cancelled() && needs.trusted.result != 'cancelled' && needs.untrusted.result != 'cancelled' }}
     permissions: {}
     needs: [trusted, untrusted]
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,145 +5,38 @@ on:
     branches: [main]
   pull_request:
 
-concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
+permissions: {}
 
-permissions:
-  contents: read
-
-env:
-  CARGO_TERM_COLOR: always
-
-# Actions are pinned to full commit SHAs. A mutable tag like @v2 or @stable can
-# be retargeted at any time, which would swap out executable CI code without
-# review.
 jobs:
-  test:
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
-    timeout-minutes: 15
+  trusted:
+    if: ${{ github.actor == 'jdx' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'jdx')) }}
     permissions:
       contents: read
       id-token: write
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
+    uses: ./.github/workflows/ci-impl.yml
 
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
-        with:
-          components: clippy, rustfmt
-
-      - uses: ./.github/actions/mbx
-
-      # The tasks live in mise.toml so that a laptop and this runner invoke the
-      # same commands — the same reason tak.toml exists for benchmarks.
-      # This job only runs Rust tasks. The docs and release jobs install the
-      # Node/usage and communique tools they need separately.
-      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
-        with:
-          install: false
-
-      # The whole premise of this project is that instruction counts are stable
-      # enough to gate on. That path is a subprocess call, so it can only be
-      # exercised where valgrind exists — and it once shipped having never run.
-      # Installing it here is what keeps tests/counters.rs meaningful.
-      - name: Install valgrind
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends valgrind
-
-      - run: valgrind --version
-
-      - run: mise run lint
-      - run: mise run test
-
-  docs:
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
-    timeout-minutes: 15
+  untrusted:
+    if: ${{ github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx')) }}
     permissions:
       contents: read
-      id-token: write
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
-      - uses: ./.github/actions/mbx
-      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
-      - run: mise run docs:check
+    uses: ./.github/workflows/ci-impl.yml
 
-  # macOS has no usable cachegrind, so counters are expected to be absent here.
-  # This job asserts the degradation path rather than the measurement path.
-  test-macos:
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'macos-latest' || 'namespace-profile-endev-macos-arm64' }}
-    timeout-minutes: 15
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
-      - uses: ./.github/actions/mbx
-      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
-        with:
-          install: false
-      - run: mise run test
-
-  # docker/Dockerfile is the documented way to get instruction counts on macOS
-  # and Windows, where there is no usable valgrind. Nothing built it, so it sat
-  # broken from the asset-picker extraction onward — the build stage never
-  # copied crates/, and cargo failed at manifest resolution. This job is the
-  # guard that keeps the documented path working.
-  docker:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      # Built without a layer cache on purpose. The dependency set is small
-      # enough that a fully cold build takes about 25 seconds, which is not
-      # worth the buildx + cache-export machinery it would take to avoid.
-      - name: Build the image
-        run: docker build -f docker/Dockerfile -t tak .
-
-      - run: docker run --rm tak --version
-
-      # `tak run` degrades to wall clock when valgrind is missing instead of
-      # failing — correct for a macOS host, but it means a bare run inside the
-      # image would pass having measured nothing. The image exists solely to
-      # provide the counter, so assert the counter is in the output.
-      - name: Instruction counting works inside the image
-        run: |
-          out=$(docker run --rm tak run --bench smoke --runs 2 -- /bin/echo hi)
-          echo "$out"
-          grep -qE '^[[:space:]]*instructions[[:space:]]+[0-9]+' <<<"$out" \
-            || { echo "::error::image produced no instruction count"; exit 1; }
-
-  # Single fan-in gate, so branch protection requires one check instead of an
-  # enumerated list that goes stale every time a job is added or renamed. It
-  # also catches *skipped* jobs, which a required check would otherwise treat
-  # as passing.
   final:
+    name: final
+    if: ${{ always() && !cancelled() }}
     permissions: {}
-    needs:
-      - test
-      - test-macos
-      - docker
-      - docs
+    needs: [trusted, untrusted]
     runs-on: ubuntu-latest
     timeout-minutes: 1
-    # Run on success or upstream failure but skip when the workflow is cancelled
-    # — `always()` would override `cancel-in-progress` and waste a runner.
-    if: ${{ !cancelled() }}
     steps:
-      - name: Check job results
-        if: |
-          needs.test.result != 'success' ||
-          needs.test-macos.result != 'success' ||
-          needs.docker.result != 'success' ||
-          needs.docs.result != 'success'
-        run: exit 1
-      - run: echo "All CI jobs completed successfully"
+      - name: Check selected workflow result
+        env:
+          TRUSTED_RESULT: ${{ needs.trusted.result }}
+          UNTRUSTED_RESULT: ${{ needs.untrusted.result }}
+        run: |
+          if [[ "$TRUSTED_RESULT" == success && "$UNTRUSTED_RESULT" == skipped ]] ||
+             [[ "$TRUSTED_RESULT" == skipped && "$UNTRUSTED_RESULT" == success ]]; then
+            exit 0
+          fi
+          echo "trusted=$TRUSTED_RESULT untrusted=$UNTRUSTED_RESULT"
+          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,7 @@ permissions: {}
 
 jobs:
   trusted:
-    # Temporary pilot probe: force this PR through the untrusted caller.
-    if: ${{ github.actor != 'jdx' }}
+    if: ${{ github.actor == 'jdx' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'jdx')) }}
     permissions:
       contents: read
       id-token: write
@@ -20,7 +19,7 @@ jobs:
       mbx-backend: server
 
   untrusted:
-    if: ${{ github.actor == 'jdx' }}
+    if: ${{ github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx')) }}
     permissions:
       contents: read
     uses: ./.github/workflows/ci-impl.yml


### PR DESCRIPTION
## Summary

- cap untrusted CI at `contents: read`, so it cannot mint GitHub OIDC tokens
- grant `id-token: write` only to trusted runs authored and initiated by `jdx`
- preserve the existing CI implementation and `final` fan-in check

This follows up #60.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI permission boundaries and branch-protection gating logic; a mistake in trusted/untrusted `if` conditions or the new `final` job could skip real failures or grant OIDC to untrusted code.
> 
> **Overview**
> Splits CI into **trusted** and **untrusted** reusable workflow paths so only maintainer-initiated runs get `id-token: write` and the mbx **server** cache; everyone else runs with `contents: read` only and **github** cache backend passed explicitly from the caller.
> 
> The former monolithic `ci.yml` jobs move into new **`ci-impl.yml`** (`workflow_call` with `trusted` + `mbx-backend`). Untrusted Linux jobs **assert OIDC token env vars are empty** before other steps. Top-level **`ci.yml`** fans in through **`final`**, requiring exactly one of trusted/untrusted to succeed (the other skipped).
> 
> The **mbx** composite action gains a **`backend` input** (default `auto`) and widens auto-selection to treat non-`jdx` actors like fork PRs for the GitHub backend.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 081a27584ec8ec0b9c1603043f6fa7242c46f241. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **CI/CD Improvements**
  - Added broader automated validation across Linux and macOS environments, documentation checks, and Docker build instructions.
  - Improved workflow cancellation handling to reduce redundant runs and provide clearer completion status.
  - Strengthened permissions and execution safeguards for contributions from less-trusted sources.
  - Standardized action versions and shared configuration for more consistent, reliable checks.
- **Bug Fixes**
  - Corrected backend selection for automated runs initiated outside trusted sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->