### PR TITLE
chore(ci): update mr-boxington action pin

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -17,12 +17,12 @@ runs:
   steps:
     - name: Restore the fork PR cache mirror
       if: inputs.mirror-github-cache == 'true' && github.actor == 'jdx' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: jdx/mr-boxington-action@ccdc5852f8bd93375379830a75f24794407443df
+      uses: jdx/mr-boxington-action@0bb0a01e0b2b3f34db827eddc8307bd4b1fb48ec
       with:
         version: 0.5.4
         backend: github
         cache-links: ${{ inputs.cache-links }}
-    - uses: jdx/mr-boxington-action@ccdc5852f8bd93375379830a75f24794407443df
+    - uses: jdx/mr-boxington-action@0bb0a01e0b2b3f34db827eddc8307bd4b1fb48ec
       with:
         version: 0.5.4
         cache-links: ${{ inputs.cache-links }}


### PR DESCRIPTION
Update `jdx/mr-boxington-action` to `0bb0a01e0b2b3f34db827eddc8307bd4b1fb48ec`, which scopes generated cache keys by Rust compiler identity.

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only dependency pin with no application code changes; main effect is potentially colder caches or fewer incorrect cache hits until keys stabilize.
> 
> **Overview**
> Bumps the pinned `jdx/mr-boxington-action` commit in **`.github/actions/mbx/action.yml`** for both the fork PR cache-mirror step and the main mbx setup step (from `ccdc585…` to `0bb0a01…`). Workflow inputs, backends, and `version: 0.5.4` are unchanged.
> 
> The new action revision is expected to **include Rust compiler identity in cache keys**, so CI caches should not be reused across incompatible `rustc` builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bd59034886be4149a83a7e34fc0b08d67a27190. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->