### PR TITLE
ci: back mbx with the GitHub Actions cache alone

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -1,13 +1,7 @@
 name: Set up mbx
-description: Select the trusted jdx server or fork-safe GitHub cache backend
+description: Set up mbx with the GitHub Actions cache backend
 
 inputs:
-  backend:
-    description: Explicit backend for structurally trusted or untrusted callers
-    default: auto
-  mirror-github-cache:
-    description: Mirror a trusted main build into the restore-only cache used by fork PRs
-    default: "false"
   cache-links:
     description: Cache native links; "auto" enables this on Linux
     default: auto
@@ -18,20 +12,9 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Restore the fork PR cache mirror
-      if: inputs.mirror-github-cache == 'true' && github.actor == 'jdx' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: jdx/mr-boxington-action@906ad32aec2915c312aceb21c2354cc8c0548f5f
+    - uses: jdx/mr-boxington-action@906ad32aec2915c312aceb21c2354cc8c0548f5f
       with:
         version: 0.6.0
         backend: github
         cache-links: ${{ inputs.cache-links }}
         toolchain: ${{ inputs.toolchain }}
-    - uses: jdx/mr-boxington-action@906ad32aec2915c312aceb21c2354cc8c0548f5f
-      with:
-        version: 0.6.0
-        cache-links: ${{ inputs.cache-links }}
-        toolchain: ${{ inputs.toolchain }}
-        backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}
-        server-url: https://cache.mise.jdx.dev
-        namespace: jdx/tak
-        oidc-audience: https://cache.mise.jdx.dev

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -6,9 +6,6 @@ on:
       trusted:
         required: true
         type: boolean
-      mbx-backend:
-        required: true
-        type: string
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -39,9 +36,6 @@ jobs:
           components: clippy, rustfmt
 
       - uses: ./.github/actions/mbx
-        with:
-          backend: ${{ inputs.mbx-backend }}
-          mirror-github-cache: "true"
 
       # The tasks live in mise.toml so that a laptop and this runner invoke the
       # same commands — the same reason tak.toml exists for benchmarks.
@@ -72,8 +66,6 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
       - uses: ./.github/actions/mbx
-        with:
-          backend: ${{ inputs.mbx-backend }}
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
       - run: mise run docs:check
 
@@ -88,9 +80,6 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
       - uses: ./.github/actions/mbx
-        with:
-          backend: ${{ inputs.mbx-backend }}
-          mirror-github-cache: "true"
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
         with:
           install: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
     uses: ./.github/workflows/ci-impl.yml
     with:
       trusted: true
-      mbx-backend: server
 
   untrusted:
     if: ${{ github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx')) }}
@@ -25,7 +24,6 @@ jobs:
     uses: ./.github/workflows/ci-impl.yml
     with:
       trusted: false
-      mbx-backend: github
 
   final:
     name: final


### PR DESCRIPTION
Retires the remote cache server from CI: every job now uses mbx's GitHub Actions cache backend. Removes the backend-selection expression, the `mbx-backend` workflow plumbing, the fork-PR cache mirror, and the server-warming workflow — all of which existed to route trusted builds at cache.mise.jdx.dev. mbx itself stays.

`id-token: write` grants are left in place where they may serve Pages deploys or attestations; they can be tightened separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change to build caching; no app logic, though trusted CI may see slower or colder caches without the remote server.
> 
> **Overview**
> **CI now routes all mbx setup through the GitHub Actions cache backend**, dropping the trusted/untrusted split that pointed maintainer builds at `cache.mise.jdx.dev`.
> 
> The composite **`.github/actions/mbx`** action is simplified: `backend` and `mirror-github-cache` inputs, the fork-PR cache mirror step, and `server-url` / OIDC settings are removed; **`backend: github`** is fixed on `mr-boxington-action`.
> 
> **`ci-impl.yml`** no longer accepts or forwards **`mbx-backend`**, and jobs call mbx without mirror flags. **`ci.yml`** stops passing `mbx-backend: server` vs `github` into the trusted and untrusted workflow paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb965fd339f4549b7d80ac9406297bbbbb204193. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized build caching on the GitHub Actions cache backend.
  * Removed configurable cache backend and cache mirroring options.
  * Simplified continuous integration workflows by eliminating backend configuration inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->