### PR TITLE
chore: adopt mr-boxington 1.1 cargo shim

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -14,7 +14,7 @@ runs:
   steps:
     - uses: jdx/mr-boxington-action@906ad32aec2915c312aceb21c2354cc8c0548f5f
       with:
-        version: 0.6.0
+        version: 1.1.0
         backend: github
         cache-links: ${{ inputs.cache-links }}
         toolchain: ${{ inputs.toolchain }}

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -1,14 +1,6 @@
 name: Set up mbx
 description: Set up mbx with the GitHub Actions cache backend
 
-inputs:
-  cache-links:
-    description: Cache native links; "auto" enables this on Linux
-    default: auto
-  toolchain:
-    description: Rust toolchain named explicitly by the build
-    required: false
-
 runs:
   using: composite
   steps:
@@ -17,5 +9,3 @@ runs:
         version: 1.1.0
         backend: github
         cache-generation: v2
-        cache-links: ${{ inputs.cache-links }}
-        toolchain: ${{ inputs.toolchain }}

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -12,9 +12,10 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: jdx/mr-boxington-action@906ad32aec2915c312aceb21c2354cc8c0548f5f
+    - uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563
       with:
         version: 1.1.0
         backend: github
+        cache-generation: v2
         cache-links: ${{ inputs.cache-links }}
         toolchain: ${{ inputs.toolchain }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,9 @@ or creates a development papercut, rerun the exact equivalent command from
 check. If bypassed Cargo succeeds, surface the mismatch and recommend a
 [mr-boxington Discussion](https://github.com/jdx/mr-boxington/discussions) with
 the repository and commit, OS, `mbx --version`, `mbx doctor`, and both commands
-and outputs. Do not permanently disable the shim, and do not post externally
-without user authorization.
+and outputs. Redact secrets, absolute cache paths, remote URLs, namespaces, and
+other sensitive or identifying details. Do not permanently disable the shim,
+and do not post externally without user authorization.
 
 tak measures how much work a command does by counting instructions, and stores the results in
 the repository as git notes. Read the README before changing anything: the premise, the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,14 +2,15 @@
 
 ## mbx build cache
 
-Compilation-heavy mise tasks use `mbx`. If an mbx command fails or creates a
-development papercut, rerun the exact equivalent `cargo` command from
-`CONTRIBUTING.md`; this unblocks work without weakening the check. If Cargo
-succeeds, surface the mismatch and recommend a
+Mise installs mbx 1.1 and activates its transparent Cargo shim, so
+compilation-heavy mise tasks use ordinary `cargo` commands. If the shim fails
+or creates a development papercut, rerun the exact equivalent command from
+`CONTRIBUTING.md` with `MBX_DISABLE=1`; this unblocks work without weakening the
+check. If bypassed Cargo succeeds, surface the mismatch and recommend a
 [mr-boxington Discussion](https://github.com/jdx/mr-boxington/discussions) with
-the repository and commit, OS, `mbx --version`, both commands and outputs, the
-cache summary, and `MBX_BYPASS_LOG` details when relevant. Do not silently make
-Cargo the permanent path, and do not post externally without user authorization.
+the repository and commit, OS, `mbx --version`, `mbx doctor`, and both commands
+and outputs. Do not permanently disable the shim, and do not post externally
+without user authorization.
 
 tak measures how much work a command does by counting instructions, and stores the results in
 the repository as git notes. Read the README before changing anything: the premise, the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,4 +19,6 @@ MBX_DISABLE=1 cargo clippy --all-targets -- -D warnings
 If bypassed Cargo succeeds where the shim fails, or mbx introduces a papercut, please start a
 [mr-boxington Discussion](https://github.com/jdx/mr-boxington/discussions).
 Include the repository and commit, operating system, `mbx --version`,
-`mbx doctor`, and both commands and their output.
+`mbx doctor`, and both commands and their output. Before posting, redact
+secrets, absolute cache paths, remote URLs, namespaces, and other sensitive or
+identifying details.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,19 +4,19 @@ Use the mise tasks documented in `AGENTS.md` for development and validation.
 
 ## mbx build cache
 
-The normal `mise run build`, `mise run test`, and `mise run lint` workflows use
-[mbx](https://mr-boxington.jdx.dev) for compilation-heavy Cargo work. If mbx
-appears to be the problem, use the equivalent Cargo commands to unblock
-yourself without skipping or weakening the check:
+`mise install` installs [mbx](https://mr-boxington.jdx.dev) 1.1 and activates
+its transparent Cargo shim. The normal `mise run build`, `mise run test`, and
+`mise run lint` workflows therefore use the cache while invoking Cargo
+normally. To bypass mbx without skipping or weakening a check, prefix the
+equivalent Cargo command with `MBX_DISABLE=1`:
 
 ```sh
-cargo build
-cargo test --all-targets
-cargo clippy --all-targets -- -D warnings
+MBX_DISABLE=1 cargo build
+MBX_DISABLE=1 cargo test --all-targets
+MBX_DISABLE=1 cargo clippy --all-targets -- -D warnings
 ```
 
-If Cargo succeeds where mbx fails, or mbx introduces a papercut, please start a
+If bypassed Cargo succeeds where the shim fails, or mbx introduces a papercut, please start a
 [mr-boxington Discussion](https://github.com/jdx/mr-boxington/discussions).
-Include the repository and commit, operating system, `mbx --version`, both
-commands and their output, the mbx cache summary, and an `MBX_BYPASS_LOG` when
-relevant (for example, `MBX_BYPASS_LOG=mbx-bypasses.log mise run build`).
+Include the repository and commit, operating system, `mbx --version`,
+`mbx doctor`, and both commands and their output.

--- a/mise.lock
+++ b/mise.lock
@@ -41,45 +41,45 @@ url = "https://github.com/jdx/communique/releases/download/v1.3.2/communique-x86
 url_api = "https://api.github.com/repos/jdx/communique/releases/assets/525619633"
 provenance = "github-attestations"
 
-[[tools."github:jdx/mr-boxington"]]
-version = "0.6.0"
+[[tools.mr-boxington]]
+version = "1.1.0"
 backend = "github:jdx/mr-boxington"
 
-[tools."github:jdx/mr-boxington"."platforms.linux-arm64"]
-checksum = "sha256:019c98cdf8ff28e8967919ea9a549b2a7d05f8636957fc443d2fe7d00d22a5ac"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.6.0/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533792954"
+[tools.mr-boxington."platforms.linux-arm64"]
+checksum = "sha256:ded60221f2217a6e0abfe0ba3583674bae63e5a7b696c4fa145827a3a0e352af"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232514"
 provenance = "github-attestations"
 
-[tools."github:jdx/mr-boxington"."platforms.linux-arm64-musl"]
-checksum = "sha256:019c98cdf8ff28e8967919ea9a549b2a7d05f8636957fc443d2fe7d00d22a5ac"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.6.0/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533792954"
+[tools.mr-boxington."platforms.linux-arm64-musl"]
+checksum = "sha256:70a882277389bd6e6b606fc291083a857a7ef0c742b60ba5a7822cc49fe7c4ac"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232511"
 provenance = "github-attestations"
 
-[tools."github:jdx/mr-boxington"."platforms.linux-x64"]
-checksum = "sha256:156bb820fd035f846b6efb5d7210a3b816ec8842005c904f4bf40fe0a1be245e"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.6.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533792966"
+[tools.mr-boxington."platforms.linux-x64"]
+checksum = "sha256:8e718ff25e71057f758d02f3039481258cd531be914afd3f77198811d0113a74"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232519"
 provenance = "github-attestations"
 provenance_verified = true
 
-[tools."github:jdx/mr-boxington"."platforms.linux-x64-musl"]
-checksum = "sha256:156bb820fd035f846b6efb5d7210a3b816ec8842005c904f4bf40fe0a1be245e"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.6.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533792966"
+[tools.mr-boxington."platforms.linux-x64-musl"]
+checksum = "sha256:9f590a0fd0fc0a5896791257863980fe9c6035458414575749cc43e68e7ff0cf"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232518"
 provenance = "github-attestations"
 
-[tools."github:jdx/mr-boxington"."platforms.macos-arm64"]
-checksum = "sha256:bbd19a27974cdbfe7fa4a6ffef3cb29150b12ccdf3a17d2dc1e0afdd09675f25"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.6.0/mbx-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533792953"
+[tools.mr-boxington."platforms.macos-arm64"]
+checksum = "sha256:da96661534480fff35ec78e598124d208ac1f2624c6d3c287c9ae2a5852b0b29"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232513"
 provenance = "github-attestations"
 
-[tools."github:jdx/mr-boxington"."platforms.windows-x64"]
-checksum = "sha256:4a0958560ecba3253cd1d4459abf6b05b70e739e40f207ac1c17df4cd6a9e8e7"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.6.0/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533792956"
+[tools.mr-boxington."platforms.windows-x64"]
+checksum = "sha256:4adbb02bf97f00644d2e1e3930e154df39a07df1e574e0829b5d6e34474a3c95"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232517"
 provenance = "github-attestations"
 
 [[tools.node]]

--- a/mise.toml
+++ b/mise.toml
@@ -19,15 +19,21 @@ run = "cargo build"
 # Instruction-counted benchmarks (see tak.toml). The just-built release binary
 # is the measuring instrument, so this exercises the same source revision as
 # the benchmark subject without relying on a separately installed tak.
+[tasks."perf:build"]
+env = { MBX_DISABLE = "1" }
+run = "cargo build --release"
+
 [tasks.perf]
 description = "Build release mode and run the performance benchmarks"
-run = ["MBX_DISABLE=1 cargo build --release", "./target/release/tak run"]
+depends = ["perf:build"]
+run = "./target/release/tak run"
 
 # Same measurement, appended to refs/notes/tak for this commit. Nothing leaves
 # the machine until `tak push`; the perf workflows are the publisher.
 [tasks."perf:record"]
 description = "Record the performance benchmarks in git notes"
-run = ["MBX_DISABLE=1 cargo build --release", "./target/release/tak run --record"]
+depends = ["perf:build"]
+run = "./target/release/tak run --record"
 
 [tasks.test]
 description = "Run the test suite, including the cachegrind integration tests"

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-"github:jdx/mr-boxington" = "latest"
+mr-boxington = { version = "1.1.0", postinstall = "mbx setup --yes" }
 usage = "6.4.0"
 # communique rewrites release bodies and Node builds the docs. Rust-only CI jobs
 # run mise-action with `install: false` and
@@ -14,7 +14,7 @@ node = "24"
 
 [tasks.build]
 description = "Build the debug binary"
-run = "mbx build"
+run = "cargo build"
 
 # Instruction-counted benchmarks (see tak.toml). The just-built release binary
 # is the measuring instrument, so this exercises the same source revision as
@@ -33,7 +33,7 @@ run = ["cargo build --release", "./target/release/tak run --record"]
 description = "Run the test suite, including the cachegrind integration tests"
 # --all-targets so tests/counters.rs is included. Without valgrind installed it
 # skips rather than fails, which is the normal state on macOS and Windows.
-run = "mbx test --all-targets"
+run = "cargo test --all-targets"
 
 [tasks.lint]
 description = "Check formatting and run clippy"
@@ -45,7 +45,7 @@ run = "cargo fmt --check"
 
 [tasks."lint:clippy"]
 description = "Run clippy, warnings as errors"
-run = "mbx clippy --all-targets -- -D warnings"
+run = "cargo clippy --all-targets -- -D warnings"
 
 [tasks.lint-fix]
 description = "Auto-fix formatting and the clippy lints that can be fixed"

--- a/mise.toml
+++ b/mise.toml
@@ -21,13 +21,13 @@ run = "cargo build"
 # the benchmark subject without relying on a separately installed tak.
 [tasks.perf]
 description = "Build release mode and run the performance benchmarks"
-run = ["cargo build --release", "./target/release/tak run"]
+run = ["MBX_DISABLE=1 cargo build --release", "./target/release/tak run"]
 
 # Same measurement, appended to refs/notes/tak for this commit. Nothing leaves
 # the machine until `tak push`; the perf workflows are the publisher.
 [tasks."perf:record"]
 description = "Record the performance benchmarks in git notes"
-run = ["cargo build --release", "./target/release/tak run --record"]
+run = ["MBX_DISABLE=1 cargo build --release", "./target/release/tak run --record"]
 
 [tasks.test]
 description = "Run the test suite, including the cachegrind integration tests"

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-mr-boxington = { version = "1.1.0", postinstall = "mbx setup --yes" }
+mr-boxington = { version = "1.1.0", postinstall = "mbx setup --global" }
 usage = "6.4.0"
 # communique rewrites release bodies and Node builds the docs. Rust-only CI jobs
 # run mise-action with `install: false` and


### PR DESCRIPTION
## Summary

- adopt the `mr-boxington` mise shorthand at 1.1.0 with the setup post-install hook
- run compilation-heavy tasks through ordinary `cargo` commands and the transparent shim
- refresh the locked release and contributor/agent guidance

## Validation

- `MISE_LOCKED=1 mise install mr-boxington`
- `mise exec -- mbx --version` (`mbx 1.1.0`)
- `mise tasks ls`
- `git diff --check`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all local and CI Rust build/test/lint paths and bumps the GitHub Actions cache generation, so regressions would show up as compile or cache failures rather than app-runtime bugs.
> 
> **Overview**
> Upgrades **mbx** to **1.1.0** and switches compilation-heavy workflows from explicit `mbx build/test/clippy` to ordinary **`cargo`** commands backed by mbx’s **transparent Cargo shim**, installed via mise with `mbx setup --global` on postinstall. **`mise.lock`** is refreshed under the `mr-boxington` tool name with new release artifacts and checksums.
> 
> **Perf** tasks gain a shared **`perf:build`** step that runs `cargo build --release` with **`MBX_DISABLE=1`**, so benchmark builds bypass the cache while other tasks stay shimmed.
> 
> The **`.github/actions/mbx`** composite action pins a newer **mr-boxington-action** commit, drops **`cache-links`** / **`toolchain`** inputs, and sets **`cache-generation: v2`**. **`AGENTS.md`** and **`CONTRIBUTING.md`** now describe shim-first development, **`MBX_DISABLE=1`** for bypassing mbx, and updated mr-boxington discussion reporting (**`mbx doctor`**, redaction guidance).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1489de61282738da12bd48a457223c967dfc6ff3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated build tooling to mbx 1.1.0 with improved setup and cache compatibility.
  * Build, test, and lint tasks now use standard Cargo commands.
  * Added a documented option to temporarily bypass mbx during troubleshooting.
* **Documentation**
  * Updated setup and troubleshooting guidance for the latest mbx workflow.
  * Troubleshooting reports now request `mbx doctor` output and advise removing sensitive information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->