### PR TITLE
ci(perf): move benchmarks to dedicated runner

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,3 +1,4 @@
 self-hosted-runner:
   labels:
+    - jdx-perf-v1
     - bamboo-perf

--- a/.github/workflows/perf-pr-preflight.yml
+++ b/.github/workflows/perf-pr-preflight.yml
@@ -1,0 +1,16 @@
+name: perf-pr-preflight
+
+# This workflow runs only on GitHub-hosted infrastructure. Its completion wakes
+# the trusted default-branch perf-pr controller; it never executes project code.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  complete:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "The default-branch controller will independently validate this pull request."

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -203,6 +203,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
+      checks: write # attach the regression gate to the measured PR head SHA
       pull-requests: write # the sticky comment, and nothing else
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -247,6 +248,29 @@ jobs:
       # after it, and the gate is the reason this workflow exists. Without it a
       # `gh api` hiccup would skip the gate — red for the wrong reason, and with
       # no regression error to read.
+      - name: Publish the pull request check
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          status=$(cat /tmp/tak-out/status 2>/dev/null || echo 2)
+          if [ "$status" -eq 0 ]; then
+            conclusion=success
+            title='Instruction counts passed'
+          else
+            conclusion=failure
+            title='Instruction-count regression or measurement failure'
+          fi
+          test -f /tmp/tak-out/report.md || echo 'The comparison did not produce a report.' > /tmp/tak-out/report.md
+          jq -n --arg head_sha "$HEAD_SHA" --arg conclusion "$conclusion" \
+            --arg title "$title" --arg details_url "$RUN_URL" \
+            --rawfile summary /tmp/tak-out/report.md \
+            '{name:"perf / instruction-count",head_sha:$head_sha,status:"completed",conclusion:$conclusion,details_url:$details_url,output:{title:$title,summary:$summary}}' \
+            | gh api --method POST "repos/$GH_REPO/check-runs" --input -
+
       - name: Fail on a regression
         if: always()
         run: |

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -14,7 +14,7 @@ name: perf-pr
 # a series that mixes them cannot be read.
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 permissions:
@@ -27,17 +27,20 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
-  TAK_RUNNER: bamboo-v2-ubuntu24.04-x64-30vcpu-24gb-rust1.97.1
+  TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-tak-rust1.97.1
 
 jobs:
   measure:
     name: Compare instruction counts
-    if: github.event.pull_request.user.login == 'jdx'
+    if: github.event.pull_request.user.login == 'jdx' && github.event.pull_request.head.repo.full_name == github.repository
     # Same runner class as perf.yml and perf-backfill.yml. Absolute counts shift
     # between machine types by more than a real regression does, so a comparison
     # across runner classes is not a comparison — tak refuses to make one, and
     # the report would say "nothing was compared" instead of anything useful.
-    runs-on: bamboo-perf
+    runs-on: [self-hosted, jdx-perf-v1]
+    container:
+      image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922
+      options: --cpuset-cpus 0-7
     timeout-minutes: 40
     permissions:
       # Read only. This job builds and runs code from the pull request, so it
@@ -57,26 +60,42 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      # Compile inside this disposable VM. Restoring target/ can relabel a
-      # binary built on a different runner class as a Bamboo measurement.
+      # Compile inside the pinned job container. Restoring target/ could relabel
+      # a binary built on another runner class as a jdx-perf-v1 measurement.
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
         with:
           cache: false
         env:
           MISE_LOCKED: "1"
 
-      - name: Install valgrind
+      - name: Runner metadata
         run: |
-          command -v valgrind || {
-            sudo apt-get update
-            sudo apt-get install -y --no-install-recommends valgrind
-          }
-          valgrind --version
+          {
+            echo '### Runner metadata'
+            echo '```text'
+            echo 'environment-revision: perf-runner@d7c0e81'
+            echo 'image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922'
+            uname -a
+            lscpu
+            mise --version
+            rustc --version
+            cargo --version
+            valgrind --version
+            for zone in /sys/class/thermal/thermal_zone*/temp; do
+              [ -r "$zone" ] && printf '%s: %s\n' "$zone" "$(cat "$zone")"
+            done
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Verify valgrind
+        run: valgrind --version
 
       # `--record` writes a git note locally and nothing more. There is no
       # `tak push` in this workflow and there should never be one.
       - name: Measure this pull request
-        run: mise run perf:record
+        run: |
+          cargo build --release
+          taskset -c 0-3 mise run perf:record
 
       - name: Find the base commit
         id: base

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -13,15 +13,17 @@ name: perf-pr
 # main contributes to the history — a branch's numbers are not the trunk's, and
 # a series that mixes them cannot be read.
 
-on:
-  pull_request_target:
-    types: [opened, synchronize, reopened]
+on: # zizmor: ignore[dangerous-triggers] validates live PR metadata before any self-hosted job
+  workflow_run:
+    workflows: [perf-pr-preflight]
+    types: [completed]
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: true
 
 env:
@@ -30,9 +32,48 @@ env:
   TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-tak-rust1.97.1
 
 jobs:
+  authorize:
+    runs-on: ubuntu-latest
+    outputs:
+      authorized: ${{ steps.pr.outputs.authorized }}
+      base_ref: ${{ steps.pr.outputs.base_ref }}
+      head_sha: ${{ steps.pr.outputs.head_sha }}
+      pr_number: ${{ steps.pr.outputs.pr_number }}
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - id: pr
+        name: Validate the pull request from the trusted default branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          TRIGGER_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          TRIGGER_EVENT: ${{ github.event.workflow_run.event }}
+          TRIGGER_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          exec 3>>"$GITHUB_OUTPUT"
+          echo 'authorized=false' >&3
+          [ "$TRIGGER_EVENT" = pull_request ] || exit 0
+          [ "$TRIGGER_CONCLUSION" = success ] || exit 0
+          [[ "$PR_NUMBER" =~ ^[0-9]+$ ]] || exit 0
+          pr="$(gh api "repos/$REPOSITORY/pulls/$PR_NUMBER")"
+          [ "$(jq -r .state <<<"$pr")" = open ] || exit 0
+          [ "$(jq -r .user.login <<<"$pr")" = jdx ] || exit 0
+          [ "$(jq -r .head.repo.full_name <<<"$pr")" = "$REPOSITORY" ] || exit 0
+          [ "$(jq -r .base.repo.full_name <<<"$pr")" = "$REPOSITORY" ] || exit 0
+          head_sha="$(jq -r .head.sha <<<"$pr")"
+          [ "$head_sha" = "$TRIGGER_SHA" ] || exit 0
+          echo 'authorized=true' >&3
+          echo "base_ref=$(jq -r .base.ref <<<"$pr")" >&3
+          echo "head_sha=$head_sha" >&3
+          echo "pr_number=$PR_NUMBER" >&3
+
   measure:
     name: Compare instruction counts
-    if: github.event.pull_request.user.login == 'jdx' && github.event.pull_request.head.repo.full_name == github.repository
+    needs: authorize
+    if: needs.authorize.outputs.authorized == 'true'
     # Same runner class as perf.yml and perf-backfill.yml. Absolute counts shift
     # between machine types by more than a real regression does, so a comparison
     # across runner classes is not a comparison — tak refuses to make one, and
@@ -54,7 +95,7 @@ jobs:
           # for the run, changes whenever main advances, and measuring it would
           # attribute a number to a commit nobody can check out. It would also
           # make the footer below name a commit the measurement is not of.
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ needs.authorize.outputs.head_sha }}
           # Needed twice over: to find the merge base, and for the sparkline,
           # which walks twenty commits of trunk history.
           fetch-depth: 0
@@ -73,7 +114,7 @@ jobs:
           {
             echo '### Runner metadata'
             echo '```text'
-            echo 'environment-revision: perf-runner@d7c0e81'
+            echo 'environment-revision: perf-runner@78e4231'
             echo 'image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922'
             uname -a
             lscpu
@@ -100,7 +141,7 @@ jobs:
       - name: Find the base commit
         id: base
         env:
-          BASE_REF: ${{ github.base_ref }}
+          BASE_REF: ${{ needs.authorize.outputs.base_ref }}
         run: |
           git fetch --quiet origin "$BASE_REF"
           # The merge base, not the branch tip: comparing against a moving
@@ -128,7 +169,7 @@ jobs:
         if: always()
         env:
           BASE_SHA: ${{ steps.base.outputs.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
         run: |
           mkdir -p /tmp/tak-out
           # A missing report means an earlier step died. Say so, rather than
@@ -157,8 +198,8 @@ jobs:
   # code: it reads an artifact and talks to the API.
   report:
     name: Report and gate
-    needs: measure
-    if: always() && github.event.pull_request.user.login == 'jdx'
+    needs: [authorize, measure]
+    if: always() && needs.authorize.outputs.authorized == 'true' && needs.measure.result != 'cancelled'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -172,11 +213,10 @@ jobs:
       # Skipped for pull requests from forks, which get a read-only token. The
       # comparison and the gate still run there; only the comment is missing.
       - name: Comment on the pull request
-        if: github.event.pull_request.head.repo.full_name == github.repository
         env:
           GH_TOKEN: ${{ github.token }}
           GH_tak: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ needs.authorize.outputs.pr_number }}
         run: |
           marker='<!-- tak-perf-pr -->'
           read -r head_sha base_sha < /tmp/tak-out/shas

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -64,7 +64,7 @@ jobs:
           {
             echo '### Runner metadata'
             echo '```text'
-            echo 'environment-revision: perf-runner@d7c0e81'
+            echo 'environment-revision: perf-runner@78e4231'
             echo 'image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922'
             uname -a
             lscpu

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -130,6 +130,25 @@ jobs:
           sha=$(cat /tmp/tak-out/sha)
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git fetch origin refs/notes/tak:refs/notes/tak || true
-          git notes --ref=tak add -f -F /tmp/tak-out/note "$sha"
-          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY}.git" refs/notes/tak
+          git fetch origin +refs/notes/tak:refs/notes/tak-remote || true
+          if git rev-parse --verify --quiet refs/notes/tak-remote >/dev/null; then
+            git update-ref refs/notes/tak refs/notes/tak-remote
+          fi
+          {
+            git notes --ref=tak show "$sha" 2>/dev/null || true
+            cat /tmp/tak-out/note
+          } | LC_ALL=C sort -u > /tmp/tak-out/merged-note
+          git notes --ref=tak add -f -F /tmp/tak-out/merged-note "$sha"
+
+          remote="https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY}.git"
+          for attempt in 1 2 3 4 5; do
+            if git push --quiet "$remote" refs/notes/tak:refs/notes/tak; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 5 ]; then
+              echo "::error::could not publish refs/notes/tak after five attempts"
+              exit 1
+            fi
+            git fetch --quiet "$remote" +refs/notes/tak:refs/notes/tak-remote
+            git notes --ref=tak merge -s cat_sort_uniq refs/notes/tak-remote
+          done

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -27,7 +27,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
-  TAK_RUNNER: bamboo-v2-ubuntu24.04-x64-30vcpu-24gb-rust1.97.1
+  TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-tak-rust1.97.1
 
 jobs:
   measure:
@@ -35,17 +35,20 @@ jobs:
     # Pinned to one runner class on purpose. Absolute instruction counts shift
     # between machine types by more than a real regression does, so a series
     # that wanders between runners is unreadable.
-    runs-on: bamboo-perf
+    runs-on: [self-hosted, jdx-perf-v1]
+    container:
+      image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922
+      options: --cpuset-cpus 0-7
     timeout-minutes: 30
     permissions:
-      contents: write # pushing refs/notes/tak is a write to this repository
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
-      # Compile inside this disposable VM. Restoring target/ can relabel a
-      # binary built on a different runner class as a Bamboo measurement.
+      # Compile inside the pinned job container. Restoring target/ could relabel
+      # a binary built on another runner class as a jdx-perf-v1 measurement.
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
         with:
           cache: false
@@ -56,35 +59,77 @@ jobs:
       # to ~0.02% run-to-run where wall clock on this same hardware moves by
       # 4-20%. Without it tak still records timing, but the series stops being
       # precise enough to detect anything.
-      - name: Install valgrind
+      - name: Runner metadata
         run: |
-          command -v valgrind || {
-            sudo apt-get update
-            sudo apt-get install -y --no-install-recommends valgrind
-          }
-          valgrind --version
+          {
+            echo '### Runner metadata'
+            echo '```text'
+            echo 'environment-revision: perf-runner@d7c0e81'
+            echo 'image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922'
+            uname -a
+            lscpu
+            mise --version
+            rustc --version
+            cargo --version
+            valgrind --version
+            for zone in /sys/class/thermal/thermal_zone*/temp; do
+              [ -r "$zone" ] && printf '%s: %s\n' "$zone" "$(cat "$zone")"
+            done
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Verify valgrind
+        run: valgrind --version
 
       - name: Measure and record
-        run: mise run perf:record
-
-      # persist-credentials: false means the push needs its own auth. Same
-      # pattern as bench-refresh.yml: re-point origin rather than pushing to a
-      # one-shot URL, so tak's retry path has a remote to fetch from when it
-      # loses a race.
-      #
-      # Only main publishes. workflow_dispatch can be pointed at any branch or
-      # tag, and refs/notes/tak is a shared baseline that should hold main's
-      # history and nothing else. Gating the push rather than the whole job
-      # means a dispatch on a branch still measures and still prints its
-      # numbers in the summary — it just keeps them local.
-      - name: Push measurements
+        run: |
+          cargo build --release
+          taskset -c 0-3 mise run perf:record
+      - name: Package measurement note
         if: github.ref == 'refs/heads/main'
+        run: |
+          mkdir -p /tmp/tak-out
+          git notes --ref=tak show HEAD > /tmp/tak-out/note
+          git rev-parse HEAD > /tmp/tak-out/sha
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: github.ref == 'refs/heads/main'
+        with:
+          name: tak-measurement
+          path: /tmp/tak-out
+          retention-days: 1
+          if-no-files-found: error
+
+      - name: Summary
+        run: ./target/release/tak history >> "$GITHUB_STEP_SUMMARY"
+
+  publish:
+    name: Publish measurement note
+    needs: measure
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: tak-measurement
+          path: /tmp/tak-out
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Publish refs/notes/tak
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}
         run: |
-          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY}.git"
-          ./target/release/tak push
-
-      - name: Summary
-        run: ./target/release/tak history >> "$GITHUB_STEP_SUMMARY"
+          sha=$(cat /tmp/tak-out/sha)
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin refs/notes/tak:refs/notes/tak || true
+          git notes --ref=tak add -f -F /tmp/tak-out/note "$sha"
+          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY}.git" refs/notes/tak


### PR DESCRIPTION
Routes Cachegrind benchmarks to the dedicated `jdx-perf-v1` appliance. PRs use a GitHub-hosted `pull_request` preflight and a trusted default-branch `workflow_run` controller that revalidates the live PR author, repository, state, and exact head SHA before scheduling the read-only measurement job. The appliance independently rejects workflow refs outside the approved performance controllers on `main`. Write operations remain in separate GitHub-hosted jobs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how untrusted PR code reaches self-hosted infra and how git notes are published; misconfiguration could skip gates or break the baseline series, though the authorize split and read-only measure job reduce blast radius.
> 
> **Overview**
> Moves Cachegrind / instruction-count CI from **bamboo-perf** to a dedicated **`jdx-perf-v1`** self-hosted runner with a **pinned `ghcr.io/jdx/perf-runner` container**, CPU pinning (`--cpuset-cpus`, `taskset`), explicit `cargo build --release`, and **runner metadata** in the job summary (replacing on-the-fly valgrind installs).
> 
> **PR perf (`perf-pr`)** no longer triggers directly on `pull_request`. A new **`perf-pr-preflight`** workflow runs on GitHub-hosted runners only; **`perf-pr`** then runs on `workflow_run` with an **`authorize`** job that re-fetches live PR metadata (author `jdx`, same-repo head/base, open state, head SHA match) before any self-hosted work. Measurement stays read-only; **`report`** gains **`checks: write`** and publishes a **`perf / instruction-count`** check on the PR head SHA.
> 
> **Main perf (`perf.yml`)** splits publishing: the measure job drops **`contents: write`**, uploads the git note as an artifact, and a separate **GitHub-hosted `publish`** job pushes **`refs/notes/tak`** with fetch/merge/retry logic instead of running `tak push` on the appliance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b839b70119dc70fdafcdce9a7459a99555a3875b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->