### PR TITLE
ci(github): add performance artifact actions

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -26,7 +26,7 @@ steps:
       artifact: /tmp/tak-out/measurement.json
       expect: ${{ github.sha }}
       token: ${{ github.token }}
-      version: v0.0.9
+      version: RELEASE_CONTAINING_ARTIFACT_COMMANDS
       sha256: SHA256_FROM_THE_RELEASE
 ```
 

--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -1,0 +1,56 @@
+# Tak GitHub Actions
+
+Tak is pre-v1. Pin these actions to a full commit SHA and expect their inputs to change before
+1.0.
+
+## Publish a measurement artifact
+
+Run this only in a GitHub-hosted job that checks out the trusted target revision. The action
+downloads an exact Tak release archive, verifies a caller-pinned SHA-256, and invokes
+`tak artifact publish` with authentication held only in process environment:
+
+```yaml
+permissions:
+  contents: write
+steps:
+  - uses: actions/checkout@FULL_COMMIT_SHA
+    with:
+      fetch-depth: 0
+      persist-credentials: false
+  - uses: actions/download-artifact@FULL_COMMIT_SHA
+    with:
+      name: tak-measurement
+      path: /tmp/tak-out
+  - uses: jdx/tak/.github/actions/publish-artifact@FULL_COMMIT_SHA
+    with:
+      artifact: /tmp/tak-out/measurement.json
+      expect: ${{ github.sha }}
+      token: ${{ github.token }}
+      version: v0.0.9
+      sha256: SHA256_FROM_THE_RELEASE
+```
+
+## Report a pull request comparison
+
+The controlling workflow must independently validate the pull request number and full head
+SHA. The action treats the downloaded report as untrusted, bounds its size, verifies that its
+head prefix agrees, posts one sticky comment, creates a check on the full head SHA, and fails
+when the recorded comparison status is nonzero:
+
+```yaml
+permissions:
+  checks: write
+  pull-requests: write
+steps:
+  - uses: actions/download-artifact@FULL_COMMIT_SHA
+    with:
+      name: tak-report
+      path: /tmp/tak-out
+  - uses: jdx/tak/.github/actions/report-pr@FULL_COMMIT_SHA
+    with:
+      artifact-directory: /tmp/tak-out
+      head-sha: ${{ needs.authorize.outputs.head_sha }}
+      marker: <!--my-cli-perf-pr-->
+      pr-number: ${{ needs.authorize.outputs.pr_number }}
+      token: ${{ github.token }}
+```

--- a/.github/actions/publish-artifact/action.yml
+++ b/.github/actions/publish-artifact/action.yml
@@ -1,0 +1,44 @@
+name: Publish Tak measurement artifact
+description: Verify a pinned Tak release and publish a trusted measurement artifact
+
+inputs:
+  artifact:
+    description: Path to the file produced by tak artifact export
+    required: true
+  expect:
+    description: Trusted revision the artifact must target
+    required: true
+  remote:
+    description: Git remote to synchronize with
+    required: false
+    default: origin
+  token:
+    description: Token with contents write permission
+    required: true
+  version:
+    description: Exact Tak release tag, such as v0.0.9
+    required: true
+  sha256:
+    description: SHA-256 of the x86_64-unknown-linux-musl release archive
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - id: install
+      name: Install checksum-pinned Tak
+      shell: bash
+      env:
+        TAK_VERSION: ${{ inputs.version }}
+        TAK_SHA256: ${{ inputs.sha256 }}
+      run: "$GITHUB_ACTION_PATH/install.sh"
+
+    - name: Validate and publish the artifact
+      shell: bash
+      env:
+        ARTIFACT: ${{ inputs.artifact }}
+        EXPECT_REV: ${{ inputs.expect }}
+        GH_TOKEN: ${{ inputs.token }}
+        REMOTE: ${{ inputs.remote }}
+        TAK_BIN: ${{ steps.install.outputs.bin }}
+      run: "$GITHUB_ACTION_PATH/publish.sh"

--- a/.github/actions/publish-artifact/action.yml
+++ b/.github/actions/publish-artifact/action.yml
@@ -16,7 +16,7 @@ inputs:
     description: Token with contents write permission
     required: true
   version:
-    description: Exact Tak release tag, such as v0.0.9
+    description: Exact Tak release tag containing the artifact commands
     required: true
   sha256:
     description: SHA-256 of the x86_64-unknown-linux-musl release archive

--- a/.github/actions/publish-artifact/install.sh
+++ b/.github/actions/publish-artifact/install.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+[[ ${RUNNER_OS:-} == Linux && ${RUNNER_ARCH:-} == X64 ]] || {
+  echo "::error::publish-artifact currently supports only Linux X64 hosted runners"
+  exit 1
+}
+[[ ${TAK_VERSION:-} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+  echo "::error::version must be an exact stable Tak tag, such as v0.0.9"
+  exit 1
+}
+[[ ${TAK_SHA256:-} =~ ^[0-9a-f]{64}$ ]] || {
+  echo "::error::sha256 must be 64 lowercase hexadecimal characters"
+  exit 1
+}
+
+install_dir="${RUNNER_TEMP:?}/tak-${TAK_VERSION}-${TAK_SHA256}"
+archive="$install_dir/tak.tar.gz"
+mkdir -p "$install_dir"
+
+if ! printf '%s  %s\n' "$TAK_SHA256" "$archive" | sha256sum --check --status 2>/dev/null; then
+  download="$install_dir/tak.tar.gz.download"
+  curl --proto '=https' --tlsv1.2 --fail --location --silent --show-error \
+    "https://github.com/jdx/tak/releases/download/${TAK_VERSION}/tak-x86_64-unknown-linux-musl.tar.gz" \
+    --output "$download"
+  printf '%s  %s\n' "$TAK_SHA256" "$download" | sha256sum --check --status
+  mv "$download" "$archive"
+fi
+
+tar -xzf "$archive" -C "$install_dir" tak
+chmod 0755 "$install_dir/tak"
+echo "bin=$install_dir/tak" >> "${GITHUB_OUTPUT:?}"

--- a/.github/actions/publish-artifact/publish.sh
+++ b/.github/actions/publish-artifact/publish.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+[[ -f ${ARTIFACT:?} ]] || {
+  echo "::error::Tak artifact does not exist: $ARTIFACT"
+  exit 1
+}
+[[ -n ${EXPECT_REV:?} ]] || {
+  echo "::error::expect must name a trusted revision"
+  exit 1
+}
+[[ -n ${GH_TOKEN:?} ]] || {
+  echo "::error::token is required"
+  exit 1
+}
+
+# Pass authentication as an ephemeral Git configuration inherited by Tak's git
+# subprocesses. Nothing is written to .git/config or a credential helper.
+basic="$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\r\n')"
+export GIT_CONFIG_COUNT=1
+export GIT_CONFIG_KEY_0=http.https://github.com/.extraheader
+export GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $basic"
+
+"${TAK_BIN:?}" artifact publish "$ARTIFACT" --expect "$EXPECT_REV" --remote "${REMOTE:-origin}"

--- a/.github/actions/report-pr/action.yml
+++ b/.github/actions/report-pr/action.yml
@@ -1,0 +1,37 @@
+name: Report Tak pull request comparison
+description: Post a sticky comparison and attach a check run to the measured head SHA
+
+inputs:
+  artifact-directory:
+    description: Directory containing report.md, status, and shas
+    required: true
+  check-name:
+    description: Stable pull request check name
+    required: false
+    default: perf / instruction-count
+  head-sha:
+    description: Independently validated pull request head SHA
+    required: true
+  marker:
+    description: Unique HTML comment marker for the sticky comment
+    required: true
+  pr-number:
+    description: Independently validated pull request number
+    required: true
+  token:
+    description: Token with checks write and pull-requests write permissions
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Publish comment and check
+      shell: bash
+      env:
+        ARTIFACT_DIRECTORY: ${{ inputs.artifact-directory }}
+        CHECK_NAME: ${{ inputs.check-name }}
+        GH_TOKEN: ${{ inputs.token }}
+        HEAD_SHA: ${{ inputs.head-sha }}
+        MARKER: ${{ inputs.marker }}
+        PR_NUMBER: ${{ inputs.pr-number }}
+      run: "$GITHUB_ACTION_PATH/report.sh"

--- a/.github/actions/report-pr/report.sh
+++ b/.github/actions/report-pr/report.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+[[ ${HEAD_SHA:-} =~ ^[0-9a-f]{40}$ ]] || {
+  echo "::error::head-sha must be a full lowercase commit SHA"
+  exit 1
+}
+[[ ${PR_NUMBER:-} =~ ^[1-9][0-9]*$ ]] || {
+  echo "::error::pr-number must be a positive integer"
+  exit 1
+}
+[[ ${MARKER:-} =~ ^\<!--[a-zA-Z0-9_:/.-]+--\>$ ]] || {
+  echo "::error::marker must be a simple HTML comment without whitespace"
+  exit 1
+}
+[[ -n ${GH_TOKEN:-} && -n ${GITHUB_REPOSITORY:-} ]] || {
+  echo "::error::token and GITHUB_REPOSITORY are required"
+  exit 1
+}
+
+directory=${ARTIFACT_DIRECTORY:?}
+report="$directory/report.md"
+status_file="$directory/status"
+shas="$directory/shas"
+[[ -f $report && ! -L $report \
+  && -f $status_file && ! -L $status_file \
+  && -f $shas && ! -L $shas ]] || {
+  echo "::error::artifact directory must contain regular, non-symlink report.md, status, and shas files"
+  exit 1
+}
+[[ $(wc -c < "$report") -le 60000 ]] || {
+  echo "::error::report.md exceeds the 60000-byte comment limit"
+  exit 1
+}
+[[ $(wc -c < "$status_file") -le 16 && $(wc -c < "$shas") -le 128 ]] || {
+  echo "::error::artifact metadata exceeds its size limit"
+  exit 1
+}
+
+status=$(tr -d '[:space:]' < "$status_file")
+[[ $status =~ ^[0-9]{1,3}$ && $status -le 255 ]] || {
+  echo "::error::status must contain one exit status from 0 through 255"
+  exit 1
+}
+read -r artifact_head base_sha extra < "$shas" || true
+[[ -z ${extra:-} && ${artifact_head:-} == "${HEAD_SHA:0:12}" ]] || {
+  echo "::error::artifact head does not match the independently validated head SHA"
+  exit 1
+}
+[[ ${base_sha:-} =~ ^[0-9a-f]{12}$ ]] || base_sha=unknown
+
+if [[ $status -eq 0 ]]; then
+  conclusion=success
+  title='Instruction counts passed'
+else
+  conclusion=failure
+  title='Instruction-count regression or measurement failure'
+fi
+run_url="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID:?}"
+
+# Create the check first: a comment API failure must not hide the actual gate
+# result from the pull request's head commit.
+jq -n --arg name "${CHECK_NAME:-perf / instruction-count}" --arg head_sha "$HEAD_SHA" \
+  --arg conclusion "$conclusion" --arg title "$title" --arg details_url "$run_url" \
+  --rawfile summary "$report" \
+  '{name:$name,head_sha:$head_sha,status:"completed",conclusion:$conclusion,details_url:$details_url,output:{title:$title,summary:$summary}}' \
+  | gh api --method POST "repos/$GITHUB_REPOSITORY/check-runs" --input - >/dev/null
+
+{
+  printf '%s\n' "$MARKER"
+  printf '### Instruction counts\n\n'
+  cat "$report"
+  # shellcheck disable=SC2016 # Markdown code spans, not shell expansion.
+  printf '\n<sub>`%s` vs `%s` · measured on the performance runner.</sub>\n' \
+    "${HEAD_SHA:0:12}" "$base_sha"
+} > "$directory/comment.md"
+
+existing="$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" --paginate \
+  --jq ".[] | select(.body | contains(\"$MARKER\")) | .id" | tail -n1)"
+if [[ -n $existing ]]; then
+  gh api --method PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$existing" \
+    --field body="$(cat "$directory/comment.md")" >/dev/null
+else
+  gh api --method POST "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+    --field body="$(cat "$directory/comment.md")" >/dev/null
+fi
+
+if [[ $status -ne 0 ]]; then
+  echo "::error::$title"
+  exit 1
+fi

--- a/.github/actions/tests/test.sh
+++ b/.github/actions/tests/test.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+actions_dir=$(cd "$(dirname "$0")/.." && pwd)
+test_dir=$(mktemp -d)
+
+if [[ $(uname -s) == Linux && $(uname -m) == x86_64 ]]; then
+  output="$test_dir/install-output"
+  RUNNER_OS=Linux \
+    RUNNER_ARCH=X64 \
+    RUNNER_TEMP="$test_dir" \
+    GITHUB_OUTPUT="$output" \
+    TAK_VERSION=v0.0.8 \
+    TAK_SHA256=442c866a7572936f639c39edb32042a2f60d78a9dd86116a429f6e31cc9840fe \
+    "$actions_dir/publish-artifact/install.sh"
+  tak_bin=$(cut -d= -f2- "$output")
+  [[ -x $tak_bin ]]
+  "$tak_bin" --version | grep -q 'tak 0.0.8'
+fi
+
+fake_bin="$test_dir/bin"
+artifact_dir="$test_dir/artifact"
+mkdir -p "$fake_bin" "$artifact_dir"
+printf '{}\n' > "$artifact_dir/measurement.json"
+cat > "$fake_bin/tak" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" > "$TAK_CAPTURE/args"
+printf '%s\n' "$GIT_CONFIG_COUNT" "$GIT_CONFIG_KEY_0" "$GIT_CONFIG_VALUE_0" \
+  > "$TAK_CAPTURE/git-config"
+EOF
+chmod 0755 "$fake_bin/tak"
+
+ARTIFACT="$artifact_dir/measurement.json" \
+  EXPECT_REV=0123456789abcdef0123456789abcdef01234567 \
+  GH_TOKEN=test-token \
+  REMOTE=origin \
+  TAK_BIN="$fake_bin/tak" \
+  TAK_CAPTURE="$test_dir" \
+  "$actions_dir/publish-artifact/publish.sh"
+grep -q '^artifact publish .*measurement.json --expect 0123456789abcdef0123456789abcdef01234567 --remote origin$' \
+  "$test_dir/args"
+grep -q '^http.https://github.com/.extraheader$' "$test_dir/git-config"
+
+cat > "$fake_bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$GH_CAPTURE/calls"
+case "$*" in
+  *check-runs*) cat > "$GH_CAPTURE/check.json" ;;
+  *'comments --paginate'*) ;;
+  *issues/*/comments*) printf '%s\n' "$*" > "$GH_CAPTURE/comment-call" ;;
+  *) echo "unexpected gh invocation: $*" >&2; exit 1 ;;
+esac
+EOF
+chmod 0755 "$fake_bin/gh"
+
+head_sha=0123456789abcdef0123456789abcdef01234567
+printf 'No instruction-count regression.\n' > "$artifact_dir/report.md"
+printf '0\n' > "$artifact_dir/status"
+printf '0123456789ab fedcba987654\n' > "$artifact_dir/shas"
+
+PATH="$fake_bin:$PATH" \
+  GH_CAPTURE="$test_dir" \
+  GH_TOKEN=test-token \
+  GITHUB_REPOSITORY=jdx/example \
+  GITHUB_RUN_ID=123 \
+  ARTIFACT_DIRECTORY="$artifact_dir" \
+  HEAD_SHA="$head_sha" \
+  PR_NUMBER=42 \
+  MARKER='<!--example-perf-pr-->' \
+  "$actions_dir/report-pr/report.sh"
+
+jq -e --arg sha "$head_sha" \
+  '.head_sha == $sha and .conclusion == "success" and .status == "completed"' \
+  "$test_dir/check.json" >/dev/null
+grep -q 'issues/42/comments' "$test_dir/comment-call"
+grep -q '<!--example-perf-pr-->' "$artifact_dir/comment.md"
+
+printf 'ffffffffffff fedcba987654\n' > "$artifact_dir/shas"
+calls_before=$(wc -l < "$test_dir/calls")
+if PATH="$fake_bin:$PATH" \
+  GH_CAPTURE="$test_dir" \
+  GH_TOKEN=test-token \
+  GITHUB_REPOSITORY=jdx/example \
+  GITHUB_RUN_ID=123 \
+  ARTIFACT_DIRECTORY="$artifact_dir" \
+  HEAD_SHA="$head_sha" \
+  PR_NUMBER=42 \
+  MARKER='<!--example-perf-pr-->' \
+  "$actions_dir/report-pr/report.sh"; then
+  echo 'report action accepted an artifact for a different head SHA' >&2
+  exit 1
+fi
+[[ $(wc -l < "$test_dir/calls") -eq $calls_before ]]

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -117,6 +117,19 @@ jobs:
           grep -qE '^[[:space:]]*instructions[[:space:]]+[0-9]+' <<<"$out" \
             || { echo "::error::image produced no instruction count"; exit 1; }
 
+  actions:
+    permissions: {}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Lint action scripts
+        run: shellcheck .github/actions/{publish-artifact,report-pr,tests}/*.sh
+      - name: Test action scripts
+        run: .github/actions/tests/test.sh
+
   # Single fan-in gate, so branch protection requires one check instead of an
   # enumerated list that goes stale every time a job is added or renamed. It
   # also catches *skipped* jobs, which a required check would otherwise treat
@@ -128,6 +141,7 @@ jobs:
       - test-macos
       - docker
       - docs
+      - actions
     runs-on: ubuntu-latest
     timeout-minutes: 1
     # Run on success or upstream failure but skip when the workflow is cancelled
@@ -139,6 +153,7 @@ jobs:
           needs.test.result != 'success' ||
           needs.test-macos.result != 'success' ||
           needs.docker.result != 'success' ||
-          needs.docs.result != 'success'
+          needs.docs.result != 'success' ||
+          needs.actions.result != 'success'
         run: exit 1
       - run: echo "All CI jobs completed successfully"


### PR DESCRIPTION
## Summary

- add a checksum-pinned hosted publisher for Tak measurement artifacts
- add a hosted reporter that binds downloaded output to an independently validated PR head SHA
- keep Git credentials ephemeral and bound artifact sizes before API writes
- exercise install, publish, report, and commit-mismatch rejection paths in CI

## Dependency

Depends on #72 and the Tak release containing `tak artifact export` / `tak artifact publish`. Tak is pre-v1, so consumers pin both the action commit and exact Tak release archive checksum.

## Validation

- `shellcheck .github/actions/{publish-artifact,report-pr,tests}/*.sh`
- `.github/actions/tests/test.sh`
- `uvx zizmor --persona=auditor .github/actions`
- YAML parsing for both action manifests and the CI workflow

Prepared with Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Actions handle GitHub tokens, pinned binary downloads, and PR/check APIs; mitigations are strong but misconfiguration or a bad pinned checksum could still affect repo contents or PR gating.
> 
> **Overview**
> Adds two **composite GitHub Actions** for instruction-count CI: **`publish-artifact`** downloads a **SHA-256–pinned** Tak release, then runs `tak artifact publish` with **ephemeral** GitHub auth via `GIT_CONFIG_*` (no `.git/config` writes). **`report-pr`** treats downloaded report output as **untrusted**—validates file shapes/sizes, requires the artifact head prefix to match a workflow-supplied full **head SHA**, posts or updates a **marker-based sticky PR comment**, creates a **check run on the head commit first** (so comment failures don’t hide the gate), and fails on nonzero comparison status.
> 
> Includes **`.github/actions/README.md`** with pin-by-commit usage examples and a new CI **`actions`** job (**shellcheck** + **`test.sh`**) wired into the **`final`** fan-in gate; tests cover real install on Linux x64, fake `tak`/`gh` publish and report paths, and **rejection when `shas` doesn’t match** the validated head.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0c1bb549f31b9a55b5a763681da6c6c094b7d9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->