### PR TITLE
ci(perf): use GitHub-hosted Rust for benchmarks

### DIFF
--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -44,6 +44,7 @@ jobs:
     permissions:
       contents: read
     outputs:
+      image_version: ${{ steps.toolchain.outputs.image_version }}
       rust_version: ${{ steps.toolchain.outputs.rust_version }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -53,8 +54,11 @@ jobs:
       - id: toolchain
         name: Record the built-in toolchain
         run: |
+          image_version=${ImageVersion:?GitHub-hosted ImageVersion is unavailable}
           rust_version=$(rustc --version | awk '{print $2}')
+          [[ "$image_version" =~ ^[0-9]{8}\.[0-9]+\.[0-9]+$ ]]
           [[ "$rust_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          echo "image_version=$image_version" >> "$GITHUB_OUTPUT"
           echo "rust_version=$rust_version" >> "$GITHUB_OUTPUT"
       - name: Build without a shared cache
         run: cargo build --release
@@ -130,7 +134,7 @@ jobs:
       # must not hold a token that can write anything — see the `report` job.
       contents: read
     env:
-      TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-tak-gha-rust${{ needs.build.outputs.rust_version }}
+      TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-tak-gha${{ needs.build.outputs.image_version }}-rust${{ needs.build.outputs.rust_version }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -123,7 +123,7 @@ jobs:
     runs-on: [self-hosted, jdx-perf-v1]
     container:
       image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922
-      options: --cpuset-cpus 0-7 --user 1001:1001
+      options: --cpuset-cpus 0-7
     timeout-minutes: 40
     permissions:
       # Read only. This job builds and runs code from the pull request, so it
@@ -234,6 +234,12 @@ jobs:
           path: /tmp/tak-out
           retention-days: 1
           if-no-files-found: error
+
+      # Job containers run as root, while bootstrap-host.sh creates gha-runner
+      # as UID 1001. Hand the checkout back before the host cleanup hook runs.
+      - name: Restore runner ownership
+        if: always()
+        run: chown -R 1001:1001 "$GITHUB_WORKSPACE"
 
   # A separate job so the write token is never in scope while code from the
   # pull request is executing. This one checks out nothing and runs no project

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -22,6 +22,10 @@ permissions:
   contents: read
   pull-requests: read
 
+defaults:
+  run:
+    shell: bash
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: true
@@ -29,9 +33,47 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
-  TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-tak-rust1.97.1
 
 jobs:
+  build:
+    name: Build with GitHub-hosted Rust
+    needs: authorize
+    if: needs.authorize.outputs.authorized == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    outputs:
+      rust_version: ${{ steps.toolchain.outputs.rust_version }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.authorize.outputs.head_sha }}
+          persist-credentials: false
+      - id: toolchain
+        name: Record the built-in toolchain
+        run: |
+          rust_version=$(rustc --version | awk '{print $2}')
+          [[ "$rust_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          echo "rust_version=$rust_version" >> "$GITHUB_OUTPUT"
+      - name: Build without a shared cache
+        run: cargo build --release
+      - name: Package the binary and toolchain identity
+        run: |
+          mkdir -p /tmp/tak-build
+          install -m 0755 target/release/tak /tmp/tak-build/tak
+          {
+            rustc --version
+            cargo --version
+            echo "runner-image: ${ImageOS:-unknown} ${ImageVersion:-unknown}"
+          } > /tmp/tak-build/build-info
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: tak-perf-binary
+          path: /tmp/tak-build
+          retention-days: 1
+          if-no-files-found: error
+
   authorize:
     runs-on: ubuntu-latest
     outputs:
@@ -72,7 +114,7 @@ jobs:
 
   measure:
     name: Compare instruction counts
-    needs: authorize
+    needs: [authorize, build]
     if: needs.authorize.outputs.authorized == 'true'
     # Same runner class as perf.yml and perf-backfill.yml. Absolute counts shift
     # between machine types by more than a real regression does, so a comparison
@@ -81,12 +123,14 @@ jobs:
     runs-on: [self-hosted, jdx-perf-v1]
     container:
       image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922
-      options: --cpuset-cpus 0-7
+      options: --cpuset-cpus 0-7 --user 1001:1001
     timeout-minutes: 40
     permissions:
       # Read only. This job builds and runs code from the pull request, so it
       # must not hold a token that can write anything — see the `report` job.
       contents: read
+    env:
+      TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-tak-gha-rust${{ needs.build.outputs.rust_version }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -101,13 +145,15 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      # Compile inside the pinned job container. Restoring target/ could relabel
-      # a binary built on another runner class as a jdx-perf-v1 measurement.
-      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          cache: false
-        env:
-          MISE_LOCKED: "1"
+          name: tak-perf-binary
+          path: /tmp/tak-build
+
+      - name: Install the measured binary
+        run: |
+          mkdir -p target/release
+          install -m 0755 /tmp/tak-build/tak target/release/tak
 
       - name: Runner metadata
         run: |
@@ -118,9 +164,7 @@ jobs:
             echo 'image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922'
             uname -a
             lscpu
-            mise --version
-            rustc --version
-            cargo --version
+            cat /tmp/tak-build/build-info
             valgrind --version
             for zone in /sys/class/thermal/thermal_zone*/temp; do
               [ -r "$zone" ] && printf '%s: %s\n' "$zone" "$(cat "$zone")"
@@ -134,9 +178,7 @@ jobs:
       # `--record` writes a git note locally and nothing more. There is no
       # `tak push` in this workflow and there should never be one.
       - name: Measure this pull request
-        run: |
-          cargo build --release
-          taskset -c 0-3 mise run perf:record
+        run: taskset -c 0-3 ./target/release/tak run --record
 
       - name: Find the base commit
         id: base

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -16,6 +16,10 @@ on:
 
 permissions: {}
 
+defaults:
+  run:
+    shell: bash
+
 # Never two at once. Concurrent runs race the notes push; tak retries with a
 # cat_sort_uniq merge so nothing is lost, but serialising avoids the churn.
 # cancel-in-progress is off deliberately: every commit gets a measurement, and
@@ -27,33 +31,73 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
-  TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-tak-rust1.97.1
 
 jobs:
+  build:
+    name: Build with GitHub-hosted Rust
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    outputs:
+      rust_version: ${{ steps.toolchain.outputs.rust_version }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - id: toolchain
+        name: Record the built-in toolchain
+        run: |
+          rust_version=$(rustc --version | awk '{print $2}')
+          [[ "$rust_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          echo "rust_version=$rust_version" >> "$GITHUB_OUTPUT"
+      - name: Build without a shared cache
+        run: cargo build --release
+      - name: Package the binary and toolchain identity
+        run: |
+          mkdir -p /tmp/tak-build
+          install -m 0755 target/release/tak /tmp/tak-build/tak
+          {
+            rustc --version
+            cargo --version
+            echo "runner-image: ${ImageOS:-unknown} ${ImageVersion:-unknown}"
+          } > /tmp/tak-build/build-info
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: tak-perf-binary
+          path: /tmp/tak-build
+          retention-days: 1
+          if-no-files-found: error
+
   measure:
     name: Measure
+    needs: build
     # Pinned to one runner class on purpose. Absolute instruction counts shift
     # between machine types by more than a real regression does, so a series
     # that wanders between runners is unreadable.
     runs-on: [self-hosted, jdx-perf-v1]
     container:
       image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922
-      options: --cpuset-cpus 0-7
+      options: --cpuset-cpus 0-7 --user 1001:1001
     timeout-minutes: 30
     permissions:
       contents: read
+    env:
+      TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-tak-gha-rust${{ needs.build.outputs.rust_version }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
-      # Compile inside the pinned job container. Restoring target/ could relabel
-      # a binary built on another runner class as a jdx-perf-v1 measurement.
-      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          cache: false
-        env:
-          MISE_LOCKED: "1"
+          name: tak-perf-binary
+          path: /tmp/tak-build
+
+      - name: Install the measured binary
+        run: |
+          mkdir -p target/release
+          install -m 0755 /tmp/tak-build/tak target/release/tak
 
       # cachegrind is the whole point: it counts instructions, which reproduce
       # to ~0.02% run-to-run where wall clock on this same hardware moves by
@@ -68,9 +112,7 @@ jobs:
             echo 'image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922'
             uname -a
             lscpu
-            mise --version
-            rustc --version
-            cargo --version
+            cat /tmp/tak-build/build-info
             valgrind --version
             for zone in /sys/class/thermal/thermal_zone*/temp; do
               [ -r "$zone" ] && printf '%s: %s\n' "$zone" "$(cat "$zone")"
@@ -82,9 +124,7 @@ jobs:
         run: valgrind --version
 
       - name: Measure and record
-        run: |
-          cargo build --release
-          taskset -c 0-3 mise run perf:record
+        run: taskset -c 0-3 ./target/release/tak run --record
       - name: Package measurement note
         if: github.ref == 'refs/heads/main'
         run: |

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -40,6 +40,7 @@ jobs:
     permissions:
       contents: read
     outputs:
+      image_version: ${{ steps.toolchain.outputs.image_version }}
       rust_version: ${{ steps.toolchain.outputs.rust_version }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -48,8 +49,11 @@ jobs:
       - id: toolchain
         name: Record the built-in toolchain
         run: |
+          image_version=${ImageVersion:?GitHub-hosted ImageVersion is unavailable}
           rust_version=$(rustc --version | awk '{print $2}')
+          [[ "$image_version" =~ ^[0-9]{8}\.[0-9]+\.[0-9]+$ ]]
           [[ "$rust_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          echo "image_version=$image_version" >> "$GITHUB_OUTPUT"
           echo "rust_version=$rust_version" >> "$GITHUB_OUTPUT"
       - name: Build without a shared cache
         run: cargo build --release
@@ -83,7 +87,7 @@ jobs:
     permissions:
       contents: read
     env:
-      TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-tak-gha-rust${{ needs.build.outputs.rust_version }}
+      TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-tak-gha${{ needs.build.outputs.image_version }}-rust${{ needs.build.outputs.rust_version }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -78,7 +78,7 @@ jobs:
     runs-on: [self-hosted, jdx-perf-v1]
     container:
       image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922
-      options: --cpuset-cpus 0-7 --user 1001:1001
+      options: --cpuset-cpus 0-7
     timeout-minutes: 30
     permissions:
       contents: read
@@ -142,6 +142,12 @@ jobs:
 
       - name: Summary
         run: ./target/release/tak history >> "$GITHUB_STEP_SUMMARY"
+
+      # Job containers run as root, while bootstrap-host.sh creates gha-runner
+      # as UID 1001. Hand the checkout back before the host cleanup hook runs.
+      - name: Restore runner ownership
+        if: always()
+        run: chown -R 1001:1001 "$GITHUB_WORKSPACE"
 
   publish:
     name: Publish measurement note


### PR DESCRIPTION
## Summary

- compile Tak on `ubuntu-latest` with GitHub Actions’ built-in Rust instead of adding a toolchain action
- transfer only the release binary and toolchain identity to the pinned Cachegrind container
- partition the Tak runner series by the Rust version reported by the hosted image
- use Bash explicitly for fallback packaging and run the job container as the appliance runner UID so workspace cleanup can succeed

## Failure fixed

The current controller reaches `Runner metadata` without any `rustc` in the pinned container. Its always-run report packager then uses Bash substring expansion under `sh`, and root-owned container files prevent the host cleanup hook from removing the checkout. The synthetic `perf / instruction-count` check therefore reports a measurement failure even though no comparison ran.

## Validation

- `actionlint -color .github/workflows/perf-pr.yml .github/workflows/perf.yml`
- `uvx zizmor --persona=pedantic .github/workflows/perf-pr.yml .github/workflows/perf.yml` (no medium/high findings)
- `cargo build --release` using the existing local Rust toolchain
- `./target/release/tak --version`

The `workflow_run` controller is loaded from the default branch, so the live appliance path can only exercise this revision after merge. Prepared with Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how perf baselines and PR gates are built and labeled; misaligned artifacts or runner IDs could skew comparisons, but scope is CI-only with no app runtime or secrets changes.
> 
> **Overview**
> **Perf CI now compiles `tak` on `ubuntu-latest` with the hosted image’s Rust, then runs Cachegrind on the self-hosted `perf-runner` container using only the release binary**—replacing in-container `mise`/`cargo build` that failed when the pinned image had no toolchain.
> 
> Both `perf.yml` and `perf-pr.yml` gain a **`build` job** that records `ImageVersion` and `rustc` version, uploads `tak-perf-binary` (binary + `build-info`), and wires **`measure`** to download the artifact and invoke `./target/release/tak run --record` directly. **`TAK_RUNNER`** is no longer a fixed `rust1.97.1` string; it embeds the GHA image version and Rust version so instruction-count series stay comparable when the hosted toolchain moves.
> 
> Workflow hygiene: **`defaults.run.shell: bash`** (fixes packaging that relied on Bash), runner metadata pulls toolchain info from **`build-info`**, and an **`always()` `chown`** on the workspace hands files back to UID 1001 so self-hosted cleanup succeeds after root container jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e746e482720e8e67036fc18a31729cc9dc477e88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->