### PR TITLE
chore: update mr-boxington to 1.3.0

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -6,6 +6,6 @@ runs:
   steps:
     - uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563
       with:
-        version: 1.1.0
+        version: 1.3.0
         backend: github
         cache-generation: v2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,9 @@
 
 ## mbx build cache
 
-Mise installs mbx 1.3 and activates its transparent Cargo wrapper, so
-compilation-heavy mise tasks use ordinary `cargo` commands. If the wrapper fails
+`mise install` installs mbx 1.3. `mise run` activates the project's transparent
+Cargo wrapper, so compilation-heavy mise tasks use ordinary `cargo` commands.
+Standalone Cargo commands require an activated mise shell. If the wrapper fails
 or creates a development papercut, rerun the exact equivalent command from
 `CONTRIBUTING.md` with `MBX_DISABLE=1`; this unblocks work without weakening the
 check. If bypassed Cargo succeeds, surface the mismatch and recommend a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,15 +2,15 @@
 
 ## mbx build cache
 
-Mise installs mbx 1.1 and activates its transparent Cargo shim, so
-compilation-heavy mise tasks use ordinary `cargo` commands. If the shim fails
+Mise installs mbx 1.3 and activates its transparent Cargo wrapper, so
+compilation-heavy mise tasks use ordinary `cargo` commands. If the wrapper fails
 or creates a development papercut, rerun the exact equivalent command from
 `CONTRIBUTING.md` with `MBX_DISABLE=1`; this unblocks work without weakening the
 check. If bypassed Cargo succeeds, surface the mismatch and recommend a
 [mr-boxington Discussion](https://github.com/jdx/mr-boxington/discussions) with
 the repository and commit, OS, `mbx --version`, `mbx doctor`, and both commands
 and outputs. Redact secrets, absolute cache paths, remote URLs, namespaces, and
-other sensitive or identifying details. Do not permanently disable the shim,
+other sensitive or identifying details. Do not permanently disable the wrapper,
 and do not post externally without user authorization.
 
 tak measures how much work a command does by counting instructions, and stores the results in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,8 @@ Use the mise tasks documented in `AGENTS.md` for development and validation.
 
 ## mbx build cache
 
-`mise install` installs [mbx](https://mr-boxington.jdx.dev) 1.1 and activates
-its transparent Cargo shim. The normal `mise run build`, `mise run test`, and
+`mise install` installs [mbx](https://mr-boxington.jdx.dev) 1.3 and activates
+its transparent Cargo wrapper. The normal `mise run build`, `mise run test`, and
 `mise run lint` workflows therefore use the cache while invoking Cargo
 normally. To bypass mbx without skipping or weakening a check, prefix the
 equivalent Cargo command with `MBX_DISABLE=1`:
@@ -16,7 +16,7 @@ MBX_DISABLE=1 cargo test --all-targets
 MBX_DISABLE=1 cargo clippy --all-targets -- -D warnings
 ```
 
-If bypassed Cargo succeeds where the shim fails, or mbx introduces a papercut, please start a
+If bypassed Cargo succeeds where the wrapper fails, or mbx introduces a papercut, please start a
 [mr-boxington Discussion](https://github.com/jdx/mr-boxington/discussions).
 Include the repository and commit, operating system, `mbx --version`,
 `mbx doctor`, and both commands and their output. Before posting, redact

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,11 @@ Use the mise tasks documented in `AGENTS.md` for development and validation.
 
 ## mbx build cache
 
-`mise install` installs [mbx](https://mr-boxington.jdx.dev) 1.3 and activates
-its transparent Cargo wrapper. The normal `mise run build`, `mise run test`, and
-`mise run lint` workflows therefore use the cache while invoking Cargo
-normally. To bypass mbx without skipping or weakening a check, prefix the
+`mise install` installs [mbx](https://mr-boxington.jdx.dev) 1.3. The normal
+`mise run build`, `mise run test`, and `mise run lint` workflows activate its
+transparent Cargo wrapper and therefore use the cache while invoking Cargo
+normally. Standalone Cargo commands require an activated mise shell. To bypass
+mbx without skipping or weakening a check, prefix the
 equivalent Cargo command with `MBX_DISABLE=1`:
 
 ```sh

--- a/mise.lock
+++ b/mise.lock
@@ -42,44 +42,44 @@ url_api = "https://api.github.com/repos/jdx/communique/releases/assets/525619633
 provenance = "github-attestations"
 
 [[tools.mr-boxington]]
-version = "1.1.0"
+version = "1.3.0"
 backend = "github:jdx/mr-boxington"
 
 [tools.mr-boxington."platforms.linux-arm64"]
-checksum = "sha256:ded60221f2217a6e0abfe0ba3583674bae63e5a7b696c4fa145827a3a0e352af"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232514"
+checksum = "sha256:92a8544d26324b7803eeb1d2f1c276e322e474d45e7f40b6f6a1e72ce99d6fdc"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561463"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-arm64-musl"]
-checksum = "sha256:70a882277389bd6e6b606fc291083a857a7ef0c742b60ba5a7822cc49fe7c4ac"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232511"
+checksum = "sha256:db505d360e8c1dfc6fb31ecf8172329ae2fa2417b14508e306626c6c1dba3514"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561466"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-x64"]
-checksum = "sha256:8e718ff25e71057f758d02f3039481258cd531be914afd3f77198811d0113a74"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232519"
+checksum = "sha256:0717a7dc93fdd9712d648ddab0f7e0871b50b626568c62a5c1033396f50e3940"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561483"
 provenance = "github-attestations"
 provenance_verified = true
 
 [tools.mr-boxington."platforms.linux-x64-musl"]
-checksum = "sha256:9f590a0fd0fc0a5896791257863980fe9c6035458414575749cc43e68e7ff0cf"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232518"
+checksum = "sha256:385b25699ba7429fe7cd36668667c45ff8d38f4491ebb4164e95021b22374ed0"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561484"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.macos-arm64"]
-checksum = "sha256:da96661534480fff35ec78e598124d208ac1f2624c6d3c287c9ae2a5852b0b29"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232513"
+checksum = "sha256:0d2e9d6e7d8228faafda68e2cd4190ce977a332821833c19a853c4a9dd91a82f"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561462"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.windows-x64"]
-checksum = "sha256:4adbb02bf97f00644d2e1e3930e154df39a07df1e574e0829b5d6e34474a3c95"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232517"
+checksum = "sha256:e102e3e1dd0777fc7a39c91a7805cbc8636bc4ab0c5cdc30a51b7962b8a524a7"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561482"
 provenance = "github-attestations"
 
 [[tools.node]]

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,5 @@
+min_version = "2026.8.16"
+
 [tools]
 mr-boxington = "1.3.0"
 usage = "6.4.0"

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-mr-boxington = { version = "1.1.0", postinstall = "mbx setup --global" }
+mr-boxington = "1.3.0"
 usage = "6.4.0"
 # communique rewrites release bodies and Node builds the docs. Rust-only CI jobs
 # run mise-action with `install: false` and
@@ -11,6 +11,10 @@ usage = "6.4.0"
 # untagged draft because of it. Bump with `mise lock`, deliberately.
 communique = "latest"
 node = "24"
+
+[wrappers.cargo]
+command = "mbx"
+env = { MBX_CARGO_SHIM_MODE = "1" }
 
 [tasks.build]
 description = "Build the debug binary"


### PR DESCRIPTION
## Summary
- update mr-boxington to 1.3.0 and refresh its lock entry
- commit the project-scoped Cargo wrapper instead of running global setup
- update mbx contributor and agent guidance for command wrappers

## Validation
- `mise lock --dry-run --json mr-boxington`
- verified `mbx 1.3.0` and Cargo resolution through mise command wrappers

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling and contributor-docs only; no runtime or application code changes, though developers need a recent mise and may see different Cargo resolution without `mise shell`/`mise run`.
> 
> **Overview**
> **Bumps mbx (mr-boxington) from 1.1.0 to 1.3.0** across CI (`.github/actions/mbx`), `mise.toml`, and `mise.lock`, and sets **`min_version = "2026.8.16"`** for mise.
> 
> **Replaces global `mbx setup --global` postinstall** with a **project-scoped Cargo wrapper** in `mise.toml` (`[wrappers.cargo]` → `mbx` with `MBX_CARGO_SHIM_MODE=1`), so `mise run` tasks get cached builds without mutating the developer machine globally.
> 
> **Docs** (`AGENTS.md`, `CONTRIBUTING.md`) now describe mbx 1.3, the wrapper model, and that bare `cargo` needs an activated mise shell; terminology shifts from “shim” to “wrapper.” `perf:build` still uses `MBX_DISABLE=1` for release benchmarks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18e962dc1fcf30461b393a24e29c036f1b023b51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * Updated the project’s build-cache tooling to the latest mbx 1.3 release.
  * Added transparent Cargo integration for more consistent build caching.

* **Documentation**
  * Updated setup, troubleshooting, fallback, diagnostics, and authorization guidance to reflect the current tooling and terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->