### PR TITLE
ci: use mbx server cache for trusted builds

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -1,5 +1,10 @@
 name: Set up mbx
-description: Set up mbx with the GitHub Actions cache backend
+description: Select the trusted jdx server or fork-safe GitHub cache backend
+
+inputs:
+  backend:
+    description: Explicit backend for structurally trusted or untrusted callers
+    default: auto
 
 runs:
   using: composite
@@ -7,5 +12,8 @@ runs:
     - uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563
       with:
         version: 1.3.0
-        backend: github
         cache-generation: v2
+        backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}
+        server-url: https://cache.mise.jdx.dev
+        namespace: jdx/tak
+        oidc-audience: https://cache.mise.jdx.dev

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -3,8 +3,8 @@ description: Select the trusted jdx server or fork-safe GitHub cache backend
 
 inputs:
   backend:
-    description: Explicit backend for structurally trusted or untrusted callers
-    default: auto
+    description: Backend selected by the structurally trusted caller
+    default: github
 
 runs:
   using: composite
@@ -13,7 +13,7 @@ runs:
       with:
         version: 1.3.0
         cache-generation: v2
-        backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}
+        backend: ${{ inputs.backend }}
         server-url: https://cache.mise.jdx.dev
         namespace: jdx/tak
         oidc-audience: https://cache.mise.jdx.dev

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -5,10 +5,20 @@ inputs:
   backend:
     description: Backend selected by the structurally trusted caller
     default: github
+  mirror-github-cache:
+    description: Mirror a trusted main build into the restore-only cache used by fork PRs
+    default: "false"
 
 runs:
   using: composite
   steps:
+    - name: Restore the fork PR cache mirror
+      if: inputs.mirror-github-cache == 'true' && inputs.backend == 'server' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563
+      with:
+        version: 1.3.0
+        backend: github
+        cache-generation: v2
     - uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563
       with:
         version: 1.3.0

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -36,6 +36,8 @@ jobs:
           components: clippy, rustfmt
 
       - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.trusted && 'server' || 'github' }}
 
       # The tasks live in mise.toml so that a laptop and this runner invoke the
       # same commands — the same reason tak.toml exists for benchmarks.
@@ -66,6 +68,8 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
       - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.trusted && 'server' || 'github' }}
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
       - run: mise run docs:check
 
@@ -80,6 +84,8 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
       - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.trusted && 'server' || 'github' }}
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
         with:
           install: false

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -38,6 +38,7 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: ${{ inputs.trusted && 'server' || 'github' }}
+          mirror-github-cache: "true"
 
       # The tasks live in mise.toml so that a laptop and this runner invoke the
       # same commands — the same reason tak.toml exists for benchmarks.
@@ -70,6 +71,7 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: ${{ inputs.trusted && 'server' || 'github' }}
+          mirror-github-cache: "true"
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
       - run: mise run docs:check
 


### PR DESCRIPTION
## Summary

- route trusted jdx builds through cache.mise.jdx.dev with OIDC
- retain the GitHub Actions cache backend for forks and untrusted callers
- isolate cache entries under the repository namespace

## Validation

- actionlint -shellcheck= .github/workflows/*.yml
- git diff --check

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI cache routing and OIDC-backed remote cache for trusted jobs; misconfiguration could affect build speed or cache isolation but does not touch application code.
> 
> **Overview**
> **Trusted CI** now points the shared `mbx` composite action at `cache.mise.jdx.dev` (OIDC, `jdx/tak` namespace) when `inputs.trusted` is true; **fork and untrusted runs** keep the GitHub Actions cache backend.
> 
> The `mbx` action gains `backend` and `mirror-github-cache` inputs. On **main pushes** with server backend and mirroring enabled, it first restores/writes via the GitHub backend so fork PRs can reuse a restore-only mirror of trusted build caches. **Linux test and docs** jobs enable mirroring; **macOS test** only switches backend.
> 
> **Risk:** CI-only; wrong backend selection could slow builds or leak cache scope, but trusted vs untrusted is already gated structurally in the workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3de0f8c8b9ad2eeb361906da3dfbe317bac91528. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic selection between trusted server caching and fork-safe GitHub caching.
  * Added an option to explicitly choose the caching backend.
  * Improved cache access for pull requests and untrusted execution contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->