### PR TITLE
chore(ci): update mbx to 1.3.2

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -14,11 +14,11 @@ runs:
   steps:
     - name: Restore the fork PR cache mirror
       if: inputs.mirror-github-cache == 'true' && inputs.backend == 'server' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: jdx/mr-boxington-action@v1.2.0
+      uses: jdx/mr-boxington-action@adc5c234c02592f7edd008bf81d5bc0e9584dc03 # v1.2.0
       with:
         backend: github
         cache-generation: v2
-    - uses: jdx/mr-boxington-action@v1.2.0
+    - uses: jdx/mr-boxington-action@adc5c234c02592f7edd008bf81d5bc0e9584dc03 # v1.2.0
       with:
         cache-generation: v2
         backend: ${{ inputs.backend }}

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -14,11 +14,11 @@ runs:
   steps:
     - name: Restore the fork PR cache mirror
       if: inputs.mirror-github-cache == 'true' && inputs.backend == 'server' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: jdx/mr-boxington-action@b296cd252864fce4f84642a2e0062d54621d5b41
+      uses: jdx/mr-boxington-action@v1.2.0
       with:
         backend: github
         cache-generation: v2
-    - uses: jdx/mr-boxington-action@b296cd252864fce4f84642a2e0062d54621d5b41
+    - uses: jdx/mr-boxington-action@v1.2.0
       with:
         cache-generation: v2
         backend: ${{ inputs.backend }}

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -14,14 +14,12 @@ runs:
   steps:
     - name: Restore the fork PR cache mirror
       if: inputs.mirror-github-cache == 'true' && inputs.backend == 'server' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563
+      uses: jdx/mr-boxington-action@b296cd252864fce4f84642a2e0062d54621d5b41
       with:
-        version: 1.3.0
         backend: github
         cache-generation: v2
-    - uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563
+    - uses: jdx/mr-boxington-action@b296cd252864fce4f84642a2e0062d54621d5b41
       with:
-        version: 1.3.0
         cache-generation: v2
         backend: ${{ inputs.backend }}
         server-url: https://cache.mise.jdx.dev

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -31,18 +31,18 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: ./.github/actions/mbx
-        with:
-          backend: ${{ inputs.trusted && 'server' || 'github' }}
-          mirror-github-cache: "true"
-
       # The tasks live in mise.toml so that a laptop and this runner invoke the
       # same commands — the same reason tak.toml exists for benchmarks.
       # This job only runs Rust tasks. The docs and release jobs install the
       # Node/usage and communique tools they need separately.
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
-          install: false
+          cache: false
+          install_args: mr-boxington
+      - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.trusted && 'server' || 'github' }}
+          mirror-github-cache: "true"
 
       # The whole premise of this project is that instruction counts are stable
       # enough to gate on. That path is a subprocess call, so it can only be
@@ -63,11 +63,11 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       - uses: ./.github/actions/mbx
         with:
           backend: ${{ inputs.trusted && 'server' || 'github' }}
           mirror-github-cache: "true"
-      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       - run: mise run docs:check
 
   # macOS has no usable cachegrind, so counters are expected to be absent here.
@@ -79,12 +79,13 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+        with:
+          cache: false
+          install_args: mr-boxington
       - uses: ./.github/actions/mbx
         with:
           backend: ${{ inputs.trusted && 'server' || 'github' }}
-      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
-        with:
-          install: false
       - run: mise run test
 
   # docker/Dockerfile is the documented way to get instruction counts on macOS

--- a/mise.lock
+++ b/mise.lock
@@ -42,44 +42,44 @@ url_api = "https://api.github.com/repos/jdx/communique/releases/assets/525619633
 provenance = "github-attestations"
 
 [[tools.mr-boxington]]
-version = "1.3.0"
+version = "1.3.2"
 backend = "github:jdx/mr-boxington"
 
 [tools.mr-boxington."platforms.linux-arm64"]
-checksum = "sha256:92a8544d26324b7803eeb1d2f1c276e322e474d45e7f40b6f6a1e72ce99d6fdc"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561463"
+checksum = "sha256:18aabfdfaced4316b9e9fd488d65df0915b241aa3af8e761b4df0fc0bdc1a4f7"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849887"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-arm64-musl"]
-checksum = "sha256:db505d360e8c1dfc6fb31ecf8172329ae2fa2417b14508e306626c6c1dba3514"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561466"
+checksum = "sha256:abbbcc8cc7c080febc5f6c77e1ae7af89faf15476248282f7bf4c331e836ee1b"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849885"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-x64"]
-checksum = "sha256:0717a7dc93fdd9712d648ddab0f7e0871b50b626568c62a5c1033396f50e3940"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561483"
+checksum = "sha256:6096035ae9bb47d718b7c0ca2860e1142047ebf724b37c02d3a520a4b9804d2d"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849911"
 provenance = "github-attestations"
 provenance_verified = true
 
 [tools.mr-boxington."platforms.linux-x64-musl"]
-checksum = "sha256:385b25699ba7429fe7cd36668667c45ff8d38f4491ebb4164e95021b22374ed0"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561484"
+checksum = "sha256:a31a332095ac291686777736d450b2f62658145ac173ff543f83271e44850df7"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849909"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.macos-arm64"]
-checksum = "sha256:0d2e9d6e7d8228faafda68e2cd4190ce977a332821833c19a853c4a9dd91a82f"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561462"
+checksum = "sha256:3a91ecb2d6ff4ad84662e79599d11e79eff4738c222a35ed432db4b15ade4d1e"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849886"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.windows-x64"]
-checksum = "sha256:e102e3e1dd0777fc7a39c91a7805cbc8636bc4ab0c5cdc30a51b7962b8a524a7"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561482"
+checksum = "sha256:49e3a4570034612fd7b193e4f56830bdece32c73ac92eb7f0d580c85695492df"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849907"
 provenance = "github-attestations"
 
 [[tools.node]]

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 min_version = "2026.8.16"
 
 [tools]
-mr-boxington = "1.3.0"
+mr-boxington = "1.3.2"
 usage = "6.6.1"
 # communique rewrites release bodies and Node builds the docs. Rust-only CI jobs
 # run mise-action with `install: false` and


### PR DESCRIPTION
## Summary

- use mr-boxington-action v1.2.0, pinned to its release commit
- use the project-installed mbx instead of installing a separate copy in CI
- update the project mbx pin and lockfile to 1.3.2
- keep explicit benchmark or specialized workflow installs on mbx 1.3.2 where applicable

## Validation

- mise lock mr-boxington
- git diff --check
- GitHub Actions

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated build and validation workflows for more reliable environment setup.
  - Improved caching behavior during checks, including macOS validation.
  - Updated the pull request validation process to use the latest action configuration.
  - Streamlined setup steps for documentation and test jobs.
  - Updated the project tooling version used during development and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->