### PR TITLE
ci: use runner-provided rust

### DIFF
--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -31,10 +31,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
-        with:
-          components: clippy, rustfmt
-
       - uses: ./.github/actions/mbx
         with:
           backend: ${{ inputs.trusted && 'server' || 'github' }}
@@ -67,7 +63,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
       - uses: ./.github/actions/mbx
         with:
           backend: ${{ inputs.trusted && 'server' || 'github' }}
@@ -84,7 +79,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
       - uses: ./.github/actions/mbx
         with:
           backend: ${{ inputs.trusted && 'server' || 'github' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,8 +58,6 @@ jobs:
           ref: ${{ inputs.tag }}
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
-
       # Cross-compiles and produces the archive. `dry-run` builds without
       # uploading, so a later target failing cannot leave a half-populated
       # release behind — everything is attached in one step at the end.

--- a/mise.toml
+++ b/mise.toml
@@ -5,8 +5,8 @@ mr-boxington = "1.3.0"
 usage = "6.6.0"
 # communique rewrites release bodies and Node builds the docs. Rust-only CI jobs
 # run mise-action with `install: false` and
-# dedicated jobs install only what they need. Rust itself comes from
-# rust-toolchain in CI and rustup locally.
+# dedicated jobs install only what they need. Rust comes from the runner in CI
+# and rustup locally.
 #
 # Resolved by mise.lock, not floating: 1.2.3 cleared a draft release's tag_name
 # while rewriting the body, and v0.0.3, v0.0.4 and v0.0.5 each shipped as an


### PR DESCRIPTION
## Summary

- remove stable Rust setup from test, docs, macOS, and release jobs
- use the Rust toolchain already provided by the GitHub Actions runner
- update the development-tool comment to match the CI behavior

## Validation

- `actionlint -ignore SC2035 .github/workflows/ci-impl.yml .github/workflows/release.yml`
- `git diff --check`

The ignored SC2035 advisory is pre-existing in the release attachment script.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*