### PR TITLE
ci: use shared Namespace volume for local mbx caching

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -12,6 +12,12 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Set up mise for the local mbx install
+      if: inputs.backend == 'local'
+      uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+      with:
+        install: false
+        cache: false
     - name: Mount the local mbx store on the Namespace cache volume
       if: inputs.backend == 'local'
       uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
@@ -20,7 +26,8 @@ runs:
     - name: Install mbx for local caching
       if: inputs.backend == 'local'
       shell: bash
-      run: | # zizmor: ignore[github-env] mise where returns the trusted tool install directory
+      run:
+        | # zizmor: ignore[github-env] mise where returns the trusted tool install directory
         mise install mr-boxington
         echo "$(mise where mr-boxington)" >> "$GITHUB_PATH"
         echo "MBX_REMOTE_URL=" >> "$GITHUB_ENV"

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -12,6 +12,21 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Mount the local mbx store on the Namespace cache volume
+      if: inputs.backend == 'local'
+      uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
+      with:
+        path: ${{ runner.os == 'macOS' && '~/Library/Caches/mbx' || '~/.cache/mbx' }}
+    - name: Install mbx for local caching
+      if: inputs.backend == 'local'
+      shell: bash
+      run: |
+        mise install mr-boxington
+        echo "$(mise where mr-boxington)" >> "$GITHUB_PATH"
+        echo "MBX_REMOTE_URL=" >> "$GITHUB_ENV"
+        if [[ "$RUNNER_OS" == Linux ]]; then
+          echo "MBX_CACHE_LINKS=1" >> "$GITHUB_ENV"
+        fi
     - name: Restore the fork PR cache mirror
       if: inputs.mirror-github-cache == 'true' && inputs.backend == 'local' && github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: jdx/mr-boxington-action@adc5c234c02592f7edd008bf81d5bc0e9584dc03 # v1.2.0

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -20,7 +20,7 @@ runs:
     - name: Install mbx for local caching
       if: inputs.backend == 'local'
       shell: bash
-      run: |
+      run: | # zizmor: ignore[github-env] mise where returns the trusted tool install directory
         mise install mr-boxington
         echo "$(mise where mr-boxington)" >> "$GITHUB_PATH"
         echo "MBX_REMOTE_URL=" >> "$GITHUB_ENV"

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -1,9 +1,9 @@
 name: Set up mbx
-description: Select the trusted jdx server or fork-safe GitHub cache backend
+description: Use the local Namespace volume or fork-safe GitHub cache backend
 
 inputs:
   backend:
-    description: Backend selected by the structurally trusted caller
+    description: Backend selected by the structurally trusted caller; local skips transport
     default: github
   mirror-github-cache:
     description: Mirror a trusted main build into the restore-only cache used by fork PRs
@@ -13,12 +13,13 @@ runs:
   using: composite
   steps:
     - name: Restore the fork PR cache mirror
-      if: inputs.mirror-github-cache == 'true' && inputs.backend == 'server' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      if: inputs.mirror-github-cache == 'true' && inputs.backend == 'local' && github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: jdx/mr-boxington-action@adc5c234c02592f7edd008bf81d5bc0e9584dc03 # v1.2.0
       with:
         backend: github
         cache-generation: v2
-    - uses: jdx/mr-boxington-action@adc5c234c02592f7edd008bf81d5bc0e9584dc03 # v1.2.0
+    - if: inputs.backend != 'local'
+      uses: jdx/mr-boxington-action@adc5c234c02592f7edd008bf81d5bc0e9584dc03 # v1.2.0
       with:
         cache-generation: v2
         backend: ${{ inputs.backend }}

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -19,7 +19,7 @@ env:
 # review.
 jobs:
   test:
-    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64;overrides.cache-tag=cache' }}
     timeout-minutes: 15
     steps:
       - name: Assert OIDC is unavailable to untrusted CI
@@ -57,7 +57,7 @@ jobs:
       - run: mise run test
 
   docs:
-    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64;overrides.cache-tag=cache' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -73,7 +73,7 @@ jobs:
   # macOS has no usable cachegrind, so counters are expected to be absent here.
   # This job asserts the degradation path rather than the measurement path.
   test-macos:
-    runs-on: ${{ !inputs.trusted && 'macos-latest' || 'namespace-profile-endev-macos-arm64' }}
+    runs-on: ${{ !inputs.trusted && 'macos-latest' || 'namespace-profile-endev-macos-arm64;overrides.cache-tag=cache' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -41,7 +41,7 @@ jobs:
           install_args: mr-boxington
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ inputs.trusted && 'server' || 'github' }}
+          backend: ${{ inputs.trusted && 'local' || 'github' }}
           mirror-github-cache: "true"
 
       # The whole premise of this project is that instruction counts are stable
@@ -66,7 +66,7 @@ jobs:
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ inputs.trusted && 'server' || 'github' }}
+          backend: ${{ inputs.trusted && 'local' || 'github' }}
           mirror-github-cache: "true"
       - run: mise run docs:check
 
@@ -85,7 +85,7 @@ jobs:
           install_args: mr-boxington
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ inputs.trusted && 'server' || 'github' }}
+          backend: ${{ inputs.trusted && 'local' || 'github' }}
       - run: mise run test
 
   # docker/Dockerfile is the documented way to get instruction counts on macOS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ jobs:
     if: ${{ github.actor == 'jdx' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'jdx')) }}
     permissions:
       contents: read
-      id-token: write
     uses: ./.github/workflows/ci-impl.yml
     with:
       trusted: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -63,4 +63,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v3.0.2-node.24


### PR DESCRIPTION
Keep Mr Boxington as the local build cacher for ordinary trusted Namespace jobs, using the shared Namespace volume selected by `overrides.cache-tag=cache`.

Trusted jobs use the project `mbx` wrapper locally without GitHub-cache or remote-server transport. Untrusted jobs remain on GitHub-hosted runners with the GitHub cache backend.

Privileged release, signing, deployment, and architecture-specific release jobs retain their existing isolated or untagged runner profiles.

Validation: actionlint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Trusted CI caching and runner selection changed materially; a misconfigured volume mount or local mbx path could slow or break trusted builds, but untrusted/fork paths and app code are unchanged.
> 
> **Overview**
> Trusted CI on Namespace runners now caches builds **locally** on a shared volume instead of pushing/pulling through the remote mbx server and OIDC.
> 
> The **`mbx` composite action** gains a `local` backend path: mount `~/.cache/mbx` (or macOS equivalent) via `nscloud-cache-action`, install `mr-boxington` with mise, clear `MBX_REMOTE_URL`, and set `MBX_CACHE_LINKS` on Linux. The usual `mr-boxington-action` step runs only when the backend is not `local`; main-branch cache mirroring for fork PRs still uses the GitHub backend but is gated on `local` instead of `server`.
> 
> **`ci-impl.yml`** passes `backend: local` for trusted jobs and adds `overrides.cache-tag=cache` to Linux and macOS Namespace runner labels so jobs share the cache volume. Untrusted jobs stay on GitHub runners with the `github` backend.
> 
> The **trusted workflow** in **`ci.yml`** drops **`id-token: write`** because trusted caching no longer needs OIDC to the remote cache host. **`docs.yml`** only updates the pinned comment on `deploy-pages` (same SHA).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 422eae47c299940d9b82fbaf46a5140a5fe4c61e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI/CD**
  * Trusted CI jobs now use local caching and execution for improved consistency across Linux and macOS runners.
  * Untrusted workflows and GitHub-hosted backends remain unchanged.
  * Trusted workflow permissions were reduced to the minimum required access.

* **Documentation**
  * Updated the documentation deployment workflow’s action reference while preserving its pinned implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->