### PR TITLE
ci: refresh local mbx wrapper

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -29,6 +29,7 @@ runs:
       run:
         | # zizmor: ignore[github-env] mise where returns the trusted tool install directory
         mise install mr-boxington
+        mise reshim -f
         echo "$(mise where mr-boxington)" >> "$GITHUB_PATH"
         echo "MBX_REMOTE_URL=" >> "$GITHUB_ENV"
         if [[ "$RUNNER_OS" == Linux ]]; then


### PR DESCRIPTION
Run `mise reshim -f` after installing mr-boxington in the local cache setup action. This refreshes the configured Cargo wrapper so plain `cargo` invocations use mbx.

Follow-up to the late review feedback on the Namespace cache PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line CI setup tweak with no application, auth, or data-path changes.
> 
> **Overview**
> Adds **`mise reshim -f`** immediately after **`mise install mr-boxington`** in the composite **Set up mbx** action when `backend == 'local'`.
> 
> That forces mise to regenerate shims so the **mr-boxington** Cargo wrapper is active and unqualified **`cargo`** calls in CI go through mbx for local cache builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9df7fd7e97dc4eb96c64d7fb2e20df2ca5d0a470. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->