### PR TITLE
ci(release): publish a signed packslip with each release

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -122,6 +122,10 @@ jobs:
     if: ${{ needs.release-plz-release.outputs.tag != '' }}
     permissions:
       contents: write
+      # A called workflow's token can only be narrower than its caller's, so
+      # the packslip's signing and attestation permissions are granted here.
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/release.yml
     with:
       tag: ${{ needs.release-plz-release.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # The packslip is signed with this job's OIDC identity and its
+      # artifacts are attested; neither is possible without these.
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -115,6 +119,19 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ inputs.tag }}
         run: gh release upload "$TAG" release-assets/* --repo "${{ github.repository }}" --clobber
+
+      # SHA256SUMS says the files did not change in transit; the packslip
+      # says who built them. It is one signed document holding every
+      # archive's digest, the executable inside it, the shared objects it
+      # needs from the host, and the build provenance of each file, signed
+      # keylessly with this job's identity. `tak backfill` picking an asset
+      # can check it against jdx/tak's identity with no key to distribute.
+      # See https://packslip.dev.
+      - uses: jdx/packslip@433c0c0f033e64c22f12433471768c255ef2bd93 # v0.3.0
+        with:
+          tag: ${{ inputs.tag }}
+          artifacts: release-assets/tak-*.tar.gz release-assets/tak-*.zip
+          bin: tak
 
       # Called from release-plz.yml, undrafting is that workflow's job — it
       # happens after this one returns. Run by hand, nothing else will do it,


### PR DESCRIPTION
Part of adopting [packslip](https://packslip.dev) across the jdx.dev CLIs.

`SHA256SUMS` says the files did not change in transit. It says nothing about who built them, which platform each one is for, or what they need from the host. Each release now also publishes `packslip.sigstore.json` — one signed document listing:

- every archive's sha256 and sha512
- the executable inside each one (`tak`, `tak.exe` on Windows)
- the shared objects each build needs from the host, read out of the binaries — the musl builds come out static, the gnu ones name what they load
- a build-provenance attestation per file, linked by digest
- the source repo, tag, and commit

signed keylessly with this workflow's OIDC identity, so `tak backfill` — or anything else picking an asset — verifies a download against the identity `github.com/jdx/tak` instead of a key this project would have to distribute.

### Changes

- `attach` gains `id-token: write` and `attestations: write` (needed to sign and to attest).
- `release-plz.yml` grants `upload-assets` the same two. A called workflow's token can only be equal to or narrower than its caller's, so without this the new step cannot sign or attest.
- The `jdx/packslip` action, pinned to v0.3.0, right after the assets are attached and while the release is still a draft, so the bundle lands before `release-plz` undrafts it.

`SHA256SUMS` stays out of the `artifacts` glob — it is a sidecar, not something anyone installs.

### Verification

Rehearsed `packslip create` locally against real release assets of this shape: platform, format, and `bin` resolved for every archive, and host requirements were read straight out of the binaries. `zizmor --offline` reports no findings on the changed workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes that broaden release-job OIDC/attestation permissions and add a third-party release action; no runtime application code paths change.
> 
> **Overview**
> Release CI now produces a **keyless signed packslip** (`packslip.sigstore.json`) alongside existing archives and `SHA256SUMS`, so downloads can be tied to the `github.com/jdx/tak` workflow identity instead of a distributed signing key.
> 
> The **`attach`** job in `release.yml` gains `id-token: write` and `attestations: write`, then runs the pinned **`jdx/packslip@v0.3.0`** step after `gh release upload`, targeting `tak-*.tar.gz` / `tak-*.zip` with `bin: tak` while the release is still a draft. **`upload-assets`** in `release-plz.yml` passes the same OIDC/attestation permissions into the reusable workflow, since called workflows cannot exceed the caller’s token scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff1e481846e51bebc6f6579ba9bec068f8f89739. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Release downloads now include a signed packslip document covering the published archives and binary.
  - Release assets are accompanied by attestations to improve provenance and verification.

- **Security**
  - Added signing and attestation support for release artifacts, helping users confirm their authenticity and origin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
