### PR TITLE
chore(deps): bump mr-boxington to 1.8.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Use the mise tasks documented in `AGENTS.md` for development and validation.
 
 ## mbx build cache
 
-`mise install` installs [mbx](https://mr-boxington.jdx.dev) 1.4. The normal
+`mise install` installs [mbx](https://mr-boxington.jdx.dev) 1.8. The normal
 `mise run build`, `mise run test`, and `mise run lint` workflows activate its
 transparent Cargo wrapper and therefore use the cache while invoking Cargo
 normally. Standalone Cargo commands require an activated mise shell. To bypass

--- a/mise.lock
+++ b/mise.lock
@@ -42,6 +42,47 @@ url_api = "https://api.github.com/repos/jdx/communique/releases/assets/525619633
 provenance = "github-attestations"
 
 [[tools.mr-boxington]]
+version = "1.8.1"
+backend = "github:jdx/mr-boxington"
+
+[tools.mr-boxington."platforms.linux-arm64"]
+checksum = "sha256:32ee1fa381884b62cf5f99cd5261ec566403f5a74a7579591af367d2eeb7913c"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.1/mbx-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/545207197"
+provenance = "github-attestations"
+
+[tools.mr-boxington."platforms.linux-arm64-musl"]
+checksum = "sha256:520c0d546f345f1f34880af2bcabd6e31106d2c8b58e85cf1993f4472e6ad007"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.1/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/545207199"
+provenance = "github-attestations"
+
+[tools.mr-boxington."platforms.linux-x64"]
+checksum = "sha256:d87968853cc485237e0f739c23e897e3616a569e6a17b27c40e43afec72758a6"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.1/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/545207219"
+provenance = "github-attestations"
+provenance_verified = true
+
+[tools.mr-boxington."platforms.linux-x64-musl"]
+checksum = "sha256:dcddf9c35d6c28213d396a9fac9d8987b6741dcf7e003f3dd0396458869b71e2"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.1/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/545207220"
+provenance = "github-attestations"
+
+[tools.mr-boxington."platforms.macos-arm64"]
+checksum = "sha256:541e715487e9348c389011dd2c6fc9640719e3c65ef352dd43abe84a890ba60a"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.1/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/545207201"
+provenance = "github-attestations"
+
+[tools.mr-boxington."platforms.windows-x64"]
+checksum = "sha256:7f8b25823f381da29147cc612fdb858fd3ef21cbcf6927063a5dcd9b1d65011b"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.1/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/545207206"
+provenance = "github-attestations"
+
+[[tools.mr-boxington]]
 version = "1.5.0"
 backend = "github:jdx/mr-boxington"
 

--- a/mise.lock
+++ b/mise.lock
@@ -82,47 +82,6 @@ url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.1/mbx-x86_64-p
 url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/545207206"
 provenance = "github-attestations"
 
-[[tools.mr-boxington]]
-version = "1.5.0"
-backend = "github:jdx/mr-boxington"
-
-[tools.mr-boxington."platforms.linux-arm64"]
-checksum = "sha256:3782db0c07a47334d01d426896e9f6af2480b311def2d0f0a3ab1327b57247b2"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.5.0/mbx-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/541628921"
-provenance = "github-attestations"
-
-[tools.mr-boxington."platforms.linux-arm64-musl"]
-checksum = "sha256:95e189127cf22f6586b0e7337893896dfb18b2018c7226e60844955e237234b8"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.5.0/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/541628922"
-provenance = "github-attestations"
-
-[tools.mr-boxington."platforms.linux-x64"]
-checksum = "sha256:83a5f4cb83a62cf028256c482a9f579911cc0793f79f1c2c06b83291c5c723d0"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.5.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/541629161"
-provenance = "github-attestations"
-provenance_verified = true
-
-[tools.mr-boxington."platforms.linux-x64-musl"]
-checksum = "sha256:8ffd1ffc4b53ce10ed1d0271e24d9d264e843b7be3f0a076389c4475a16e4132"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.5.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/541629170"
-provenance = "github-attestations"
-
-[tools.mr-boxington."platforms.macos-arm64"]
-checksum = "sha256:d88ebea6ebf1a5b8b4a51a440a91baeb1214fdea49a6013dfe9b56e4bd4a6c84"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.5.0/mbx-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/541628925"
-provenance = "github-attestations"
-
-[tools.mr-boxington."platforms.windows-x64"]
-checksum = "sha256:970f974d3ee56b089c34a4b03fdb80dfcc0b260b3de950009a77240c9187a4c7"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.5.0/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/541629146"
-provenance = "github-attestations"
-
 [[tools.node]]
 version = "24.19.0"
 backend = "core:node"

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 min_version = "2026.8.16"
 
 [tools]
-mr-boxington = "1.5.0"
+mr-boxington = "1.8.1"
 usage = "6.6.1"
 # communique rewrites release bodies and Node builds the docs. Rust-only CI jobs
 # run mise-action with `install: false` and


### PR DESCRIPTION
## Summary

Bump the pinned `mr-boxington` (the `mbx` Cargo wrapper) from 1.5.0 to 1.8.1, the current release. `mise.lock` updated by `mise use mr-boxington@1.8.1`.

Companion to [jdx/mise#12822](https://github.com/jdx/mise/pull/12822), which did the same bump in the mise repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling-only version bump with lockfile updates; no application or runtime code changes.
> 
> **Overview**
> Pins **mr-boxington** (`mbx`) from **1.5.0** to **1.8.1** in `mise.toml` and refreshes `mise.lock` (checksums, download URLs, and GitHub asset IDs for every supported platform).
> 
> **CONTRIBUTING.md** is updated so the documented mbx version matches the new install (**1.8**), keeping contributor guidance aligned with `mise install`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 251338ceedeb70e901e7f92919b33b086218a2ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the `mr-boxington` tool to version 1.8.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->