### PR TITLE
ci: enforce conventional commits

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,27 @@
+name: conventional-commits
+
+on: # zizmor: ignore[dangerous-triggers] reads only the PR title and executes no untrusted code
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check pull request title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          pattern='^(chore|ci|docs|feat|fix|perf|refactor|revert|security|style|test)(\([[:alnum:]][[:alnum:]./_-]*\))?!?: [[:lower:]](.*[[:graph:]])?$'
+          if [[ ! "$PR_TITLE" =~ $pattern ]]; then
+            echo "::error title=Invalid pull request title::The title does not match the required format."
+            printf 'Received title: %q\n' "$PR_TITLE"
+            echo "Use: <type>[optional scope][optional !]: <description starting lowercase>"
+            exit 1
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,14 +136,20 @@ CI writers avoid conflicts without a custom merge driver. It dedupes on **exact 
 
 ## Conventional commits
 
-`<type>(<scope>): <description>`, lowercase, imperative mood.
+PR titles must use `<type>(<scope>): <description>` with a lowercase-leading,
+imperative description. Intermediate commit subjects should use the same format.
 
-**Types:** `feat`, `fix`, `refactor`, `docs`, `style`, `perf`, `test`, `chore`, `ci`
+**Types:** `feat`, `fix`, `refactor`, `docs`, `style`, `perf`, `test`, `chore`, `ci`, `revert`, `security`
 
 Scopes are optional and mostly unused here; when one helps, use a subcommand (`run`,
 `backfill`, `history`) or a subsystem (`notes`, `measure`, `config`, `changelog`).
 
 Only `fix:` and `feat:` commits trigger a release — see the cadence guards in RELEASING.md.
+
+CI validates the pull request title and re-runs when it is edited. Intermediate
+commit subjects are not checked because pull requests are squash-merged. CI
+mechanically checks the allowed type, syntax, and lowercase-leading description;
+imperative mood remains a review rule.
 
 ## Releasing
 


### PR DESCRIPTION
## Summary

- document or connect the repository’s Conventional Commits policy for pull request titles
- validate the title on creation and every edit with the repository’s allowed types
- use a permissionless `pull_request_target` workflow with no checkout, so pull request code cannot bypass the check
- intentionally ignore intermediate commit subjects because pull requests are squash-merged using their titles

## Testing

- `actionlint .github/workflows/conventional-commits.yml`
- exercised valid, breaking-change, invalid-type, uppercase-description, and trailing-space title cases locally

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a read-only title check with minimal workflow permissions and no execution of PR code; policy/docs changes only beyond that.
> 
> **Overview**
> Adds **CI enforcement** of Conventional Commits on **pull request titles** only, aligned with squash-merge practice where the title becomes the final commit subject.
> 
> A new **`conventional-commits`** workflow runs on `pull_request_target` (opened, edited, reopened, synchronize) with **no repo permissions** and **no checkout**, validating the title against allowed types (`feat`, `fix`, `ci`, `chore`, etc., including new **`revert`** and **`security`**) plus optional scope and breaking `!`, with a **lowercase-leading** description. Failed titles surface a GitHub Actions error with format guidance.
> 
> **`AGENTS.md`** is updated to state that PR titles must follow the format, intermediate commit subjects are not checked, and imperative mood stays a human review rule while syntax is mechanical in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 390f5ed39742b85bb63d2318b3d95e67593f4a32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->