### PR TITLE
ci(release): bump packslip to v1.0.2 and drop the GH_REPO workaround

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,11 +127,7 @@ jobs:
       # keylessly with this job's identity. `tak backfill` picking an asset
       # can check it against jdx/tak's identity with no key to distribute.
       # See https://packslip.dev.
-      - uses: jdx/packslip@a6eddff2d884891faa2efbec374b48e7053df2c4 # v1.0.1
-        # `gh release upload` inside the action has no checkout to infer the
-        # repository from; drop once jdx/packslip#71 ships in a release.
-        env:
-          GH_REPO: ${{ github.repository }}
+      - uses: jdx/packslip@5c1cced7cfa661140dbc972a0de55b2b6bd81522 # v1.0.2
         with:
           tag: ${{ inputs.tag }}
           artifacts: release-assets/tak-*.tar.gz release-assets/tak-*.zip


### PR DESCRIPTION
v1.0.2 carries jdx/packslip#71, which passes `--repo` on `gh release upload`, so the `GH_REPO` env added in #96 is no longer needed. Pinned to the release commit `5c1cced`, which is what the `v1.0.2` tag points at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to a pinned third-party action; no application or auth logic affected.
> 
> **Overview**
> Updates the release workflow’s **packslip** step from **v1.0.1** to **v1.0.2** (pinned to commit `5c1cced`).
> 
> Because v1.0.2 passes `--repo` on `gh release upload` (jdx/packslip#71), the temporary **`GH_REPO`** env on that action is removed—release signing/attestation behavior is unchanged; only the action version and workaround cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2c96384cb0aab40dbe0f16860a990547e4750df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation to improve reliability when attaching artifacts to published releases.
  * Removed obsolete release configuration that is no longer required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->