### PR TITLE
chore(ci): bump packslip to v1.1.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,7 @@ jobs:
       # keylessly with this job's identity. `tak backfill` picking an asset
       # can check it against jdx/tak's identity with no key to distribute.
       # See https://packslip.dev.
-      - uses: jdx/packslip@5c1cced7cfa661140dbc972a0de55b2b6bd81522 # v1.0.2
+      - uses: jdx/packslip@a0d434ad57571c62dbd0ab5095b4eff607a71fd3 # v1.1.1
         with:
           tag: ${{ inputs.tag }}
           artifacts: release-assets/tak-*.tar.gz release-assets/tak-*.zip


### PR DESCRIPTION
Update the release workflow to use packslip v1.1.1 at its immutable commit SHA. This release pins the nested provenance action, so repositories enforcing full-length action SHAs can load the composite action.

Validation: `git diff --check`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single third-party CI action version pin in the release attach job; no application or runtime code changes.
> 
> **Overview**
> Updates the **release** workflow’s packslip step from **v1.0.2** to **v1.1.1**, pinning the action at commit `a0d434ad57571c62dbd0ab5095b4eff607a71fd3`.
> 
> The bump is mainly so packslip **v1.1.1** can pin its nested provenance action by full SHA, which keeps release signing/attestation working when the repo requires immutable action references. Inputs (`tag`, `artifacts`, `bin`) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c68e0135a55adbea46bae80e45c004f59fd6e58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release attachment workflow to use a newer version of the packaging action.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->