### PR TITLE
chore(ci): use self-repository workflow references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     if: ${{ github.actor == 'jdx' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'jdx')) }}
     permissions:
       contents: read
-    uses: ./.github/workflows/ci-impl.yml
+    uses: $/.github/workflows/ci-impl.yml
     with:
       trusted: true
 
@@ -20,7 +20,7 @@ jobs:
     if: ${{ github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx')) }}
     permissions:
       contents: read
-    uses: ./.github/workflows/ci-impl.yml
+    uses: $/.github/workflows/ci-impl.yml
     with:
       trusted: false
 

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -126,7 +126,7 @@ jobs:
       # the packslip's signing and attestation permissions are granted here.
       id-token: write
       attestations: write
-    uses: ./.github/workflows/release.yml
+    uses: $/.github/workflows/release.yml
     with:
       tag: ${{ needs.release-plz-release.outputs.tag }}
 


### PR DESCRIPTION
Zizmor 1.30.0 fails on the workspace-relative reusable workflow references. Use GitHub's self-repository syntax (`$/...`) for those calls, preserving their existing workflow targets, inputs, permissions, and secrets.

Validation: zizmor 1.30.0 passed with online audits enabled; `git diff --check` passed.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-6; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes how reusable workflows are referenced; behavior and security boundaries of the CI/release jobs should stay the same.
> 
> **Overview**
> Updates **reusable workflow `uses` paths** from workspace-relative `./.github/workflows/...` to GitHub’s **self-repository** form `$/...` in `ci.yml` (trusted/untrusted → `ci-impl.yml`) and `release-plz.yml` (`upload-assets` → `release.yml`).
> 
> **Inputs, permissions, and called workflows are unchanged**—this is a reference-syntax fix so **Zizmor 1.30.0** stops flagging the old paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d06e21f6ac3cb253bba3935fa619a372db48ba4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected reusable workflow references in continuous integration and release automation.
  * Restored proper execution of trusted, untrusted, and release asset upload jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->